### PR TITLE
Added 6, 7, 11 node versions to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 sudo: false
 language: node_js
 node_js:
+  - "11"
   - "10"
   - "9"
   - "8"
+  - "7"
+  - "6"
 
 script:
   - npm install


### PR DESCRIPTION
- Since package.json supports node engines above 6, I figured the CI build should probably include it.