### PR TITLE
fix: lazy-load React in molecule SVG export

### DIFF
--- a/packages/molecule/src/molecule.test.ts
+++ b/packages/molecule/src/molecule.test.ts
@@ -85,15 +85,15 @@ describe('Molecule', () => {
   });
 
   describe('toSVG', () => {
-    it('should export ACETONE with default settings', () => {
+    it('should export ACETONE with default settings', async () => {
       sut.load(ACETONE, MoleculeDataFormat.jnmol);
-      const svg = sut.toSVG({});
+      const svg = await sut.toSVG({});
       expect(svg).toMatchSnapshot();
     });
 
-    it('should export ACETONE and take into account color settings', () => {
+    it('should export ACETONE and take into account color settings', async () => {
       sut.load(ACETONE, MoleculeDataFormat.jnmol);
-      const svg = sut.toSVG({ colorElements: false });
+      const svg = await sut.toSVG({ colorElements: false });
       expect(svg).toMatchSnapshot();
     });
   });

--- a/packages/molecule/src/molecule.ts
+++ b/packages/molecule/src/molecule.ts
@@ -2,13 +2,7 @@ import type React from 'react';
 import { legacy_createStore as createStore } from 'redux';
 import { MoleculeDataFormat } from './models.js';
 import type { SvgExportOptions } from './models.js';
-import {
-  exportMolecule,
-  exportToSVG,
-  type IMoleculeState,
-  loadMolecule,
-  reducer,
-} from './store/index.js';
+import { exportMolecule, type IMoleculeState, loadMolecule, reducer } from './store/index.js';
 
 export class Molecule {
   private store = createStore(reducer);
@@ -33,7 +27,8 @@ export class Molecule {
     return exportMolecule(this.state, format);
   }
 
-  public toSVG(options: SvgExportOptions): React.JSX.Element {
+  public async toSVG(options: SvgExportOptions): Promise<React.JSX.Element> {
+    const { exportToSVG } = await import('./store/svg-export.js');
     return exportToSVG(this.state, options);
   }
 }

--- a/packages/molecule/src/store/selectors.ts
+++ b/packages/molecule/src/store/selectors.ts
@@ -1,0 +1,5 @@
+import type { IMoleculeState } from './reducer.js';
+
+export const exportMolecule = (molecule: IMoleculeState, _format: string): IMoleculeState => {
+  return molecule;
+};

--- a/packages/molecule/src/store/svg-export.tsx
+++ b/packages/molecule/src/store/svg-export.tsx
@@ -7,10 +7,6 @@ import {
   projectMolecule,
 } from './services/index.js';
 
-export const exportMolecule = (molecule: IMoleculeState, _format: string): IMoleculeState => {
-  return molecule;
-};
-
 export const exportToSVG = (
   molecule: IMoleculeState,
   drawOptions: SvgExportOptions


### PR DESCRIPTION
## Summary
- Split `selectors.tsx` into `selectors.ts` (no React) and `svg-export.tsx` (React-dependent)
- `toSVG()` now uses dynamic `import()` so `@chemistry/molecule` works without react installed
- `toSVG` return type: `JSX.Element` → `Promise<JSX.Element>` (breaking for SVG users)
- Consumers using only `load`, `getAtomCount`, `getBondCount`, `export` no longer need react

## Test plan
- [x] `npm run verify` passes (170 tests, all checks green)
- [x] All 6 built packages validated via ESM import without react (18/18 pass)
- [x] `toSVG` correctly returns a Promise
- [x] Snapshot tests updated for async toSVG