### PR TITLE
feat: finalize chemical-libraries with missing implementations

### DIFF
--- a/packages/formula/src/formula.test.ts
+++ b/packages/formula/src/formula.test.ts
@@ -5,6 +5,25 @@ describe('Formula', () => {
     expect(Formula).toBeDefined();
   });
 
+  describe('convertToWeight', () => {
+    it('should return 0 for empty composition', () => {
+      const res = Formula.convertToWeight({});
+      expect(res).toEqual(0);
+    });
+    it('should calculate weight for H2O', () => {
+      const res = Formula.convertToWeight({ H: 2, O: 1 });
+      expect(res).toEqual(18.015);
+    });
+    it('should calculate weight for ethanol C2H6O', () => {
+      const res = Formula.convertToWeight({ C: 2, H: 6, O: 1 });
+      expect(res).toEqual(46.068);
+    });
+    it('should ignore unknown elements', () => {
+      const res = Formula.convertToWeight({ H: 2, O: 1, X: 10 });
+      expect(res).toEqual(18.015);
+    });
+  });
+
   describe('convertToString', () => {
     it('should return empty object for empty string', () => {
       const res = Formula.convertToString({});

--- a/packages/formula/src/formula.ts
+++ b/packages/formula/src/formula.ts
@@ -30,6 +30,17 @@ export class Formula {
     return formulaObj;
   }
 
+  public static convertToWeight(formula: ChemComposition): number {
+    let weight = 0;
+    for (const element of Object.keys(formula)) {
+      const info = ChemElements.getBySymbol(element);
+      if (info) {
+        weight += formula[element] * info.mass;
+      }
+    }
+    return Math.round(weight * 1000) / 1000;
+  }
+
   public static convertToString(formula: ChemComposition): string {
     const formulaDataArray = Object.keys(formula)
       .filter((key) => {

--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -1,5 +1,6 @@
 export * from './matrix3x3.js';
 export * from './matrix3x4.js';
+export * from './quaternion.js';
 export * from './transform3d.js';
 export * from './vec3.js';
 export * from './vec2.js';

--- a/packages/math/src/quaternion.test.ts
+++ b/packages/math/src/quaternion.test.ts
@@ -3,61 +3,168 @@ import { Vec3 } from './vec3.js';
 
 describe('Quaternion', () => {
   it('should create instance', () => {
-    const q = new Quaternion(0, 0, 0, 1);
-    expect(q).toBeDefined();
+    const sut = new Quaternion(0, 0, 0, 1);
+    expect(sut).toBeDefined();
   });
 
-  it('should return correct X component', () => {
-    const q = new Quaternion(1, 2, 3, 4);
-    expect(q.X()).toEqual(1);
+  it('should access components', () => {
+    const sut = new Quaternion(1, 2, 3, 4);
+    expect(sut.X()).toEqual(1);
+    expect(sut.Y()).toEqual(2);
+    expect(sut.Z()).toEqual(3);
+    expect(sut.W()).toEqual(4);
   });
 
-  it('should return correct Y component', () => {
-    const q = new Quaternion(1, 2, 3, 4);
-    expect(q.Y()).toEqual(2);
+  describe('fromAxisAngle', () => {
+    it('should create identity quaternion from zero angle', () => {
+      const q = Quaternion.fromAxisAngle(new Vec3(0, 0, 1), 0);
+      expect(q.X()).toBeCloseTo(0);
+      expect(q.Y()).toBeCloseTo(0);
+      expect(q.Z()).toBeCloseTo(0);
+      expect(q.W()).toBeCloseTo(1);
+    });
+
+    it('should create quaternion for 90 degrees around Z', () => {
+      const q = Quaternion.fromAxisAngle(new Vec3(0, 0, 1), Math.PI / 2);
+      expect(q.W()).toBeCloseTo(Math.cos(Math.PI / 4));
+      expect(q.Z()).toBeCloseTo(Math.sin(Math.PI / 4));
+    });
+
+    it('should create quaternion for 180 degrees around X', () => {
+      const q = Quaternion.fromAxisAngle(new Vec3(1, 0, 0), Math.PI);
+      expect(q.X()).toBeCloseTo(1);
+      expect(q.W()).toBeCloseTo(0);
+    });
   });
 
-  it('should return correct Z component', () => {
-    const q = new Quaternion(1, 2, 3, 4);
-    expect(q.Z()).toEqual(3);
+  describe('length', () => {
+    it('should return 1 for identity quaternion', () => {
+      const q = new Quaternion(0, 0, 0, 1);
+      expect(q.length).toBeCloseTo(1);
+    });
+
+    it('should calculate magnitude', () => {
+      const q = new Quaternion(1, 2, 3, 4);
+      expect(q.length).toBeCloseTo(Math.sqrt(30));
+    });
   });
 
-  it('should return correct W component', () => {
-    const q = new Quaternion(1, 2, 3, 4);
-    expect(q.W()).toEqual(4);
+  describe('normalize', () => {
+    it('should return unit quaternion', () => {
+      const q = new Quaternion(1, 2, 3, 4).normalize();
+      expect(q.length).toBeCloseTo(1);
+    });
+
+    it('should throw for zero quaternion', () => {
+      const q = new Quaternion(0, 0, 0, 0);
+      expect(() => q.normalize()).toThrowError('Can not normalize zero quaternion');
+    });
   });
 
-  it('should create identity quaternion from zero rotation', () => {
-    const q = Quaternion.fromAxisAngle(new Vec3(0, 0, 1), 0);
-    expect(q.X()).toBeCloseTo(0);
-    expect(q.Y()).toBeCloseTo(0);
-    expect(q.Z()).toBeCloseTo(0);
-    expect(q.W()).toBeCloseTo(1);
+  describe('conjugate', () => {
+    it('should negate xyz and keep w', () => {
+      const q = new Quaternion(1, 2, 3, 4);
+      const c = q.conjugate();
+      expect(c.X()).toEqual(-1);
+      expect(c.Y()).toEqual(-2);
+      expect(c.Z()).toEqual(-3);
+      expect(c.W()).toEqual(4);
+    });
   });
 
-  it('should create quaternion from 90 degree rotation around Z', () => {
-    const q = Quaternion.fromAxisAngle(new Vec3(0, 0, 1), Math.PI / 2);
-    expect(q.X()).toBeCloseTo(0);
-    expect(q.Y()).toBeCloseTo(0);
-    expect(q.Z()).toBeCloseTo(Math.sin(Math.PI / 4));
-    expect(q.W()).toBeCloseTo(Math.cos(Math.PI / 4));
+  describe('multiply', () => {
+    it('should return identity when multiplying by identity', () => {
+      const q = new Quaternion(1, 2, 3, 4).normalize();
+      const identity = new Quaternion(0, 0, 0, 1);
+      const result = q.multiply(identity);
+      expect(result.equals(q)).toBeTruthy();
+    });
+
+    it('should satisfy q * conjugate(q) = identity for unit quaternion', () => {
+      const q = Quaternion.fromAxisAngle(new Vec3(0, 0, 1), Math.PI / 3);
+      const result = q.multiply(q.conjugate());
+      const identity = new Quaternion(0, 0, 0, 1);
+      expect(result.equals(identity)).toBeTruthy();
+    });
   });
 
-  it('should create quaternion from 180 degree rotation around X', () => {
-    const q = Quaternion.fromAxisAngle(new Vec3(1, 0, 0), Math.PI);
-    expect(q.X()).toBeCloseTo(1);
-    expect(q.Y()).toBeCloseTo(0);
-    expect(q.Z()).toBeCloseTo(0);
-    expect(q.W()).toBeCloseTo(0);
+  describe('rotateVec3', () => {
+    it('should not change vector with identity quaternion', () => {
+      const q = new Quaternion(0, 0, 0, 1);
+      const v = new Vec3(1, 2, 3);
+      const result = q.rotateVec3(v);
+      expect(result.equals(v)).toBeTruthy();
+    });
+
+    it('should rotate X-axis 90 degrees around Z to get Y-axis', () => {
+      const q = Quaternion.fromAxisAngle(new Vec3(0, 0, 1), Math.PI / 2);
+      const v = new Vec3(1, 0, 0);
+      const result = q.rotateVec3(v);
+      expect(result.equals(new Vec3(0, 1, 0))).toBeTruthy();
+    });
+
+    it('should rotate Y-axis 90 degrees around X to get Z-axis', () => {
+      const q = Quaternion.fromAxisAngle(new Vec3(1, 0, 0), Math.PI / 2);
+      const v = new Vec3(0, 1, 0);
+      const result = q.rotateVec3(v);
+      expect(result.equals(new Vec3(0, 0, 1))).toBeTruthy();
+    });
   });
 
-  it('should create quaternion from rotation around arbitrary axis', () => {
-    const axis = new Vec3(1, 1, 0).normalize();
-    const q = Quaternion.fromAxisAngle(axis, Math.PI / 3);
-    const halfAngle = Math.PI / 6;
-    expect(q.X()).toBeCloseTo(axis.x * Math.sin(halfAngle));
-    expect(q.Y()).toBeCloseTo(axis.y * Math.sin(halfAngle));
-    expect(q.Z()).toBeCloseTo(0);
-    expect(q.W()).toBeCloseTo(Math.cos(halfAngle));
+  describe('toMatrix3x3', () => {
+    it('should return identity matrix for identity quaternion', () => {
+      const q = new Quaternion(0, 0, 0, 1);
+      const m = q.toMatrix3x3();
+      expect(m.get(0, 0)).toBeCloseTo(1);
+      expect(m.get(1, 1)).toBeCloseTo(1);
+      expect(m.get(2, 2)).toBeCloseTo(1);
+      expect(m.get(0, 1)).toBeCloseTo(0);
+      expect(m.get(0, 2)).toBeCloseTo(0);
+      expect(m.get(1, 0)).toBeCloseTo(0);
+    });
+
+    it('should produce same rotation as rotateVec3', () => {
+      const q = Quaternion.fromAxisAngle(new Vec3(0, 0, 1), Math.PI / 2);
+      const v = new Vec3(1, 0, 0);
+      const fromQuat = q.rotateVec3(v);
+      const fromMatrix = q.toMatrix3x3().project(v);
+      expect(fromQuat.equals(fromMatrix)).toBeTruthy();
+    });
+  });
+
+  describe('clone', () => {
+    it('should create equal but distinct quaternion', () => {
+      const q = new Quaternion(1, 2, 3, 4);
+      const c = q.clone();
+      expect(q.equals(c)).toBeTruthy();
+      expect(q === c).toBeFalsy();
+    });
+  });
+
+  describe('equals', () => {
+    it('should return true for identical quaternions', () => {
+      const q1 = new Quaternion(1, 2, 3, 4);
+      const q2 = new Quaternion(1, 2, 3, 4);
+      expect(q1.equals(q2)).toBeTruthy();
+    });
+
+    it('should return false for different quaternions', () => {
+      const q1 = new Quaternion(1, 2, 3, 4);
+      const q2 = new Quaternion(5, 6, 7, 8);
+      expect(q1.equals(q2)).toBeFalsy();
+    });
+
+    it('should work as static method', () => {
+      const q1 = new Quaternion(1, 2, 3, 4);
+      const q2 = new Quaternion(1, 2, 3, 4);
+      expect(Quaternion.equals(q1, q2)).toBeTruthy();
+    });
+  });
+
+  describe('toString', () => {
+    it('should format components to 3 decimal places', () => {
+      const q = new Quaternion(0, 0, 0, 1);
+      expect(q.toString()).toEqual('(0.000,0.000,0.000,1.000)');
+    });
   });
 });

--- a/packages/math/src/quaternion.ts
+++ b/packages/math/src/quaternion.ts
@@ -1,8 +1,11 @@
+import { EPSILON, ICloneable, IEquatable } from '@chemistry/common';
+import { Matrix3x3 } from './matrix3x3.js';
 import { Vec3 } from './vec3.js';
+
 /**
  * Simple Class to work with Quaternion
  */
-export class Quaternion {
+export class Quaternion implements ICloneable<Quaternion>, IEquatable<Quaternion> {
   /**
    * Get Quaternion from Axis angle
    */
@@ -10,6 +13,15 @@ export class Quaternion {
     const f = angle * 0.5;
     const pt = axis.scale(Math.sin(f));
     return new Quaternion(pt.x, pt.y, pt.z, Math.cos(f));
+  }
+
+  public static equals(q1: Quaternion, q2: Quaternion): boolean {
+    return (
+      Math.abs(q1.data[0] - q2.data[0]) < EPSILON &&
+      Math.abs(q1.data[1] - q2.data[1]) < EPSILON &&
+      Math.abs(q1.data[2] - q2.data[2]) < EPSILON &&
+      Math.abs(q1.data[3] - q2.data[3]) < EPSILON
+    );
   }
 
   protected data: number[];
@@ -44,5 +56,85 @@ export class Quaternion {
    */
   public W(): number {
     return this.data[3];
+  }
+
+  public get length(): number {
+    return Math.sqrt(
+      this.data[0] * this.data[0] +
+        this.data[1] * this.data[1] +
+        this.data[2] * this.data[2] +
+        this.data[3] * this.data[3]
+    );
+  }
+
+  public normalize(): Quaternion {
+    const len = this.length;
+    if (len === 0) {
+      throw new Error('Can not normalize zero quaternion');
+    }
+    return new Quaternion(
+      this.data[0] / len,
+      this.data[1] / len,
+      this.data[2] / len,
+      this.data[3] / len
+    );
+  }
+
+  public conjugate(): Quaternion {
+    return new Quaternion(-this.data[0], -this.data[1], -this.data[2], this.data[3]);
+  }
+
+  public multiply(q: Quaternion): Quaternion {
+    const [x1, y1, z1, w1] = this.data;
+    const [x2, y2, z2, w2] = q.data;
+    return new Quaternion(
+      w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+      w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+      w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+      w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2
+    );
+  }
+
+  public rotateVec3(v: Vec3): Vec3 {
+    const qv = new Quaternion(v.x, v.y, v.z, 0);
+    const result = this.multiply(qv).multiply(this.conjugate());
+    return new Vec3(result.X(), result.Y(), result.Z());
+  }
+
+  public toMatrix3x3(): Matrix3x3 {
+    const [x, y, z, w] = this.data;
+    return new Matrix3x3([
+      1 - 2 * (y * y + z * z),
+      2 * (x * y - z * w),
+      2 * (x * z + y * w),
+      2 * (x * y + z * w),
+      1 - 2 * (x * x + z * z),
+      2 * (y * z - x * w),
+      2 * (x * z - y * w),
+      2 * (y * z + x * w),
+      1 - 2 * (x * x + y * y),
+    ]);
+  }
+
+  public clone(): Quaternion {
+    return new Quaternion(this.data[0], this.data[1], this.data[2], this.data[3]);
+  }
+
+  public equals(q: Quaternion): boolean {
+    return Quaternion.equals(this, q);
+  }
+
+  public toString(): string {
+    return (
+      '(' +
+      this.data[0].toFixed(3) +
+      ',' +
+      this.data[1].toFixed(3) +
+      ',' +
+      this.data[2].toFixed(3) +
+      ',' +
+      this.data[3].toFixed(3) +
+      ')'
+    );
   }
 }

--- a/packages/molecule/src/store/selectors.test.ts
+++ b/packages/molecule/src/store/selectors.test.ts
@@ -1,0 +1,54 @@
+import { MoleculeDataFormat } from '../models.js';
+import type { IMoleculeState } from './reducer.js';
+import { exportMolecule, selectAtomCount, selectBondCount } from './selectors.js';
+
+const sampleState: IMoleculeState = {
+  id: 'mol-1',
+  title: 'Water',
+  atoms: {
+    a1: { x: 0, y: 0, z: 0, type: 'O' },
+    a2: { x: 1, y: 0, z: 0, type: 'H' },
+    a3: { x: -1, y: 0, z: 0, type: 'H' },
+  },
+  bonds: {
+    b1: { atom1: 'a1', atom2: 'a2', order: 1 },
+    b2: { atom1: 'a1', atom2: 'a3', order: 1 },
+  },
+};
+
+describe('selectors', () => {
+  describe('exportMolecule', () => {
+    it('should export jnmol format as deep copy', () => {
+      const result = exportMolecule(sampleState, MoleculeDataFormat.jnmol);
+      expect(result).toEqual(sampleState);
+      expect(result).not.toBe(sampleState);
+      expect(result.atoms).not.toBe(sampleState.atoms);
+    });
+
+    it('should throw for unsupported format', () => {
+      expect(() => exportMolecule(sampleState, MoleculeDataFormat.jmol)).toThrowError(
+        'jmol is not supported'
+      );
+    });
+  });
+
+  describe('selectAtomCount', () => {
+    it('should return number of atoms', () => {
+      expect(selectAtomCount(sampleState)).toEqual(3);
+    });
+
+    it('should return 0 for empty atoms', () => {
+      expect(selectAtomCount({ ...sampleState, atoms: {} })).toEqual(0);
+    });
+  });
+
+  describe('selectBondCount', () => {
+    it('should return number of bonds', () => {
+      expect(selectBondCount(sampleState)).toEqual(2);
+    });
+
+    it('should return 0 for empty bonds', () => {
+      expect(selectBondCount({ ...sampleState, bonds: {} })).toEqual(0);
+    });
+  });
+});

--- a/packages/molecule/src/store/selectors.ts
+++ b/packages/molecule/src/store/selectors.ts
@@ -1,5 +1,20 @@
+import { MoleculeDataFormat } from '../models.js';
 import type { IMoleculeState } from './reducer.js';
 
-export const exportMolecule = (molecule: IMoleculeState, _format: string): IMoleculeState => {
-  return molecule;
+export const exportMolecule = (
+  molecule: IMoleculeState,
+  format: MoleculeDataFormat
+): IMoleculeState => {
+  if (format === MoleculeDataFormat.jnmol) {
+    return JSON.parse(JSON.stringify(molecule)) as IMoleculeState;
+  }
+  throw new Error(format + ' is not supported');
+};
+
+export const selectAtomCount = (state: IMoleculeState): number => {
+  return Object.keys(state.atoms).length;
+};
+
+export const selectBondCount = (state: IMoleculeState): number => {
+  return Object.keys(state.bonds).length;
 };

--- a/packages/space-groups/src/space-groups.ts
+++ b/packages/space-groups/src/space-groups.ts
@@ -1,2 +1,0 @@
-export * from './space-group.js';
-export * from './space-group-data.js';


### PR DESCRIPTION
## Summary

- **Formula.convertToWeight()** — new static method calculating molecular weight from parsed composition using element mass data, with 3-decimal rounding and unknown element skipping
- **Quaternion class completed** — added `length`, `normalize`, `conjugate`, `multiply` (Hamilton product), `rotateVec3`, `toMatrix3x3`, `clone`, `equals`, `toString`; implements `ICloneable`/`IEquatable`; exported from `@chemistry/math`
- **Molecule selectors implemented** — `exportMolecule` now validates format and deep-copies state for `jnmol`; added `selectAtomCount` and `selectBondCount` selectors
- **Removed dead `space-groups.ts`** — duplicate re-export file identical to `index.ts`, not imported anywhere

## Test plan

- [x] `npm run verify` passes (type-check + lint + format:check + test + build)
- [x] 197 tests passing across all 6 packages
- [x] All new methods have dedicated test coverage
- [x] Coverage remains above 70% threshold