### PR TITLE
chore: update TypeScript target to ES2024 and engines to Node >=22

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "javascript"
   ],
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.0.0",
     "npm": ">=10.0.0"
   },
   "workspaces": [

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,7 +16,7 @@
     "data formats"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -15,7 +15,7 @@
     "elements color"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/formula/package.json
+++ b/packages/formula/package.json
@@ -14,7 +14,7 @@
     "cheminformatics"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -14,7 +14,7 @@
     "math"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/molecule/package.json
+++ b/packages/molecule/package.json
@@ -21,7 +21,7 @@
     "directory": "packages/molecule"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/space-groups/package.json
+++ b/packages/space-groups/package.json
@@ -17,7 +17,7 @@
     "Symmetry Operations"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2024",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2024", "DOM"],
     "types": ["vitest/globals"],
     "noEmit": true,
     "paths": {


### PR DESCRIPTION
## Summary
- Update TypeScript `target` from `ES2020` to `ES2024` in `tsconfig.json` (also updates `lib` to match)
- Update `engines.node` from `>=20.0.0` to `>=22.0.0` in root and all 6 package `package.json` files

Aligns with `CLAUDE.md` standards: `"target": "ES2024"`, Node.js 22+.

## Test plan
- [x] `npm run verify` passes (type-check + lint + format:check + 197 tests + build)