### PR TITLE
chore: add assignee to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,28 +7,32 @@ updates:
       day: 'friday'
       time: '18:00'
       timezone: 'Europe/Prague'
+    assignees:
+      - 'vreshch'
     open-pull-requests-limit: 10
     groups:
       dev-dependencies:
         patterns:
           - '@types/*'
           - 'typescript'
+          - 'typescript-eslint'
           - 'eslint*'
           - '@eslint/*'
-          - 'typescript-eslint'
           - 'prettier'
           - 'vitest*'
           - '@vitest/*'
+          - 'jest*'
+          - 'ts-jest'
+          - '@playwright/*'
+          - 'playwright*'
+          - '@testing-library/*'
+          - 'postcss'
+          - 'autoprefixer'
+          - '@tailwindcss/*'
+          - 'tailwindcss'
         update-types:
           - 'minor'
           - 'patch'
-      react:
-        patterns:
-          - 'react'
-          - '@types/react'
-      redux:
-        patterns:
-          - 'redux'
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
@@ -40,3 +44,5 @@ updates:
       day: 'friday'
       time: '18:00'
       timezone: 'Europe/Prague'
+    assignees:
+      - 'vreshch'


### PR DESCRIPTION
Add `vreshch` as assignee to all Dependabot PRs so they appear in GitHub filters.