### PR TITLE
ci: publish only on tag push, dispatch, or merged release PR

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -52,9 +52,15 @@ jobs:
 
   publish:
     needs: [create-tag]
+    # create-tag 'skipped' alone is NOT enough: on pull_request_target it skips
+    # for EVERY merged non-release PR, which used to fire a publish attempt with
+    # an empty tag. Only tag pushes, manual dispatches, and merged release/* PRs
+    # may publish.
     if: >
       always() &&
-      (needs.create-tag.result == 'success' || needs.create-tag.result == 'skipped')
+      (needs.create-tag.result == 'success' ||
+       (needs.create-tag.result == 'skipped' &&
+        (github.event_name == 'push' || github.event_name == 'workflow_dispatch')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Caught by the friday-train-verify watchdog on its first dispatch (agentage/automation#232): release-build's publish job ran on EVERY merged PR because create-tag=skipped satisfied its condition, attempting a GitHub release with an empty tag (red run 30498793005; npm untouched - the already-published guard held). Publish now requires a successful create-tag (merged release/* PR) or an explicit tag-push/workflow_dispatch.