### PR TITLE
ci: run release train on plain UTC cron, drop Prague hour gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'friday'
-      time: '18:00'
-      timezone: 'Europe/Prague'
+      time: '16:00'
+      timezone: 'Etc/UTC'
     assignees:
       - 'vreshch'
     open-pull-requests-limit: 10
@@ -20,8 +20,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'friday'
-      time: '18:00'
-      timezone: 'Europe/Prague'
+      time: '16:00'
+      timezone: 'Etc/UTC'
     assignees:
       - 'vreshch'
     open-pull-requests-limit: 5

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -10,8 +10,7 @@ name: Release Prepare
 # squash commit and dispatch release-build.yml explicitly.
 on:
   schedule:
-    # Friday 20:00 Europe/Prague, both DST offsets; the gate job filters.
-    - cron: '0 18 * * 5'
+    # Single UTC cron. Late cron = train departs late, not gated away.
     - cron: '0 19 * * 5'
   workflow_dispatch:
     inputs:
@@ -31,33 +30,8 @@ permissions:
   actions: write
 
 jobs:
-  prague-gate:
-    name: Friday 20:00 Prague gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      go: ${{ steps.gate.outputs.go }}
-    steps:
-      - name: Check local Prague hour (DST-proof)
-        id: gate
-        run: |
-          if [ "${{ github.event_name }}" != "schedule" ]; then
-            echo "workflow_dispatch - bypassing hour gate."
-            echo "go=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          HOUR=$(TZ=Europe/Prague date +%H)
-          if [ "$HOUR" = "20" ]; then
-            echo "go=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Prague hour is $HOUR, not 20 - wrong DST cron slot, skipping."
-            echo "go=false" >> "$GITHUB_OUTPUT"
-          fi
-
   dependabot-merge:
     name: Merge green dependabot PRs
-    needs: prague-gate
-    if: needs.prague-gate.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -103,8 +77,7 @@ jobs:
 
   release:
     name: Cut minor release
-    needs: [prague-gate, dependabot-merge]
-    if: needs.prague-gate.outputs.go == 'true'
+    needs: dependabot-merge
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Run 1 (2026-07-31) shipped zero releases: GitHub fired the crons 60-115 min late, and the exact-hour Prague gate self-skipped every run green (no failure, no signal).

This moves the estate-wide fix into chemical-libraries:
- Single UTC cron '0 19 * * 5' (L0 slot) replaces the double DST cron pair.
- The prague-gate job is deleted entirely; needs/if wiring on dependabot-merge and release adjusted so the dependency chain stays intact.
- workflow_dispatch is unchanged - manual trigger still works exactly as before.
- dependabot.yml shifted from Friday 18:00 Europe/Prague to Friday 16:00 Etc/UTC.

In-train dependabot auto-merge logic (chemistry org merges its own dependabot PRs, no org-level triage) is untouched.

Part of the estate-wide UTC shift.