### PR TITLE
fix: fail release build when npm publish errors (was silently green)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -110,13 +110,26 @@ jobs:
 
       - name: Publish packages to npm
         run: |
-          # Publish in dependency order
-          npm publish -w @chemistry/common --access public || true
-          npm publish -w @chemistry/elements --access public || true
-          npm publish -w @chemistry/space-groups --access public || true
-          npm publish -w @chemistry/math --access public || true
-          npm publish -w @chemistry/formula --access public || true
-          npm publish -w @chemistry/molecule --access public || true
+          # Publish in dependency order; tolerate ONLY already-published (idempotent
+          # re-runs), fail the job on anything else (auth, network, registry).
+          publish() {
+            local OUT
+            if OUT=$(npm publish -w "$1" --access public 2>&1); then
+              echo "$1 published"
+            elif echo "$OUT" | grep -qE "EPUBLISHCONFLICT|cannot publish over the previously published"; then
+              echo "$1 already published - ok"
+            else
+              echo "$OUT"
+              echo "::error::npm publish failed for $1"
+              exit 1
+            fi
+          }
+          publish @chemistry/common
+          publish @chemistry/elements
+          publish @chemistry/space-groups
+          publish @chemistry/math
+          publish @chemistry/formula
+          publish @chemistry/molecule
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Tonight's v3.2.0 Release Build went green while every npm publish failed with 404 (expired chemistry-org NPM_TOKEN, set 2026-03-01) - the || true on each publish swallowed it. Now only already-published (EPUBLISHCONFLICT) is tolerated so re-runs stay idempotent; any other failure (auth/network/registry) fails the job loudly, which the train watchdog then catches. Re-running Release Build after the token refresh will publish 3.2.0 (tag + GH release already exist).