### PR TITLE
chore: bump typescript to ^6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint": "^10.7.0",
         "prettier": "^3.9.6",
         "react": "^19.2.8",
-        "typescript": "^5.9.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.65.0",
         "vitest": "^4.0.0"
       },
@@ -2416,7 +2416,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint": "^10.7.0",
     "prettier": "^3.9.6",
     "react": "^19.2.8",
-    "typescript": "^5.9.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0",
     "vitest": "^4.0.0"
   }


### PR DESCRIPTION
Bump typescript ^5.9.0 -> ^6.0.3 (root devDependency). typescript-eslint already ^8.65.0 (TS6-compatible). npm run verify green: type-check, lint, format:check, 197/197 tests, full build.