### PR TITLE
ci: shift Friday schedules off minute :00

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'friday'
-      time: '16:00'
+      time: '16:07'
       timezone: 'Etc/UTC'
     assignees:
       - 'vreshch'
@@ -24,7 +24,7 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'friday'
-      time: '16:00'
+      time: '16:07'
       timezone: 'Etc/UTC'
     assignees:
       - 'vreshch'

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -4,7 +4,7 @@ name: Train
 # Red run = the only alarm; there are no silent-skip states.
 on:
   schedule:
-    - cron: '0 19 * * 5'
+    - cron: '7 19 * * 5'
   workflow_dispatch:
     inputs:
       bump:


### PR DESCRIPTION
Scheduling rule: no cron may fire at minute `:00` (GitHub's :00 slot is the most contended, so runs queue).

- `train.yml`: `0 19 * * 5` -> `7 19 * * 5` (Friday 19:07 UTC)
- `dependabot.yml`: `time: '16:00'` -> `'16:07'` on both ecosystems (npm + github-actions), timezone `Etc/UTC` unchanged

Nothing else touched - same day, same hour, same ordering (dependabot 16:07 still lands well before the 19:07 train).

Verified: `npm ci && npm run format:check` green (prettier covers `.github/**` YAML).
