### PR TITLE
ci: enforce coverage thresholds, raise formula branch coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "prebuild": "rm -rf packages/*/dist",
     "build": "npm run build -w @chemistry/common -w @chemistry/elements -w @chemistry/space-groups && npm run build -w @chemistry/math -w @chemistry/formula && npm run build -w @chemistry/molecule",
-    "test": "vitest run",
+    "test": "vitest run --coverage",
     "lint": "eslint packages/*/src/",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/packages/formula/src/formula.test.ts
+++ b/packages/formula/src/formula.test.ts
@@ -37,6 +37,30 @@ describe('Formula', () => {
       const res = Formula.convertToString({ H: 2, O: 1, X: 10 });
       expect(res).toEqual('H2O');
     });
+    it('should put hydrogen first when it is not the first key', () => {
+      const res = Formula.convertToString({ O: 1, H: 2 });
+      expect(res).toEqual('H2O');
+    });
+    it('should put carbon first when it is not the first key', () => {
+      const res = Formula.convertToString({ O: 2, C: 1 });
+      expect(res).toEqual('CO2');
+    });
+    it('should order glucose in Hill notation', () => {
+      const res = Formula.convertToString({ O: 6, C: 6, H: 12 });
+      expect(res).toEqual('C6H12O6');
+    });
+    it('should order sulfuric acid as H2O4S', () => {
+      const res = Formula.convertToString({ S: 1, H: 2, O: 4 });
+      expect(res).toEqual('H2O4S');
+    });
+    it('should order carbon-free formula alphabetically', () => {
+      const res = Formula.convertToString({ O: 1, N: 2 });
+      expect(res).toEqual('N2O');
+    });
+    it('should order permanganate alphabetically', () => {
+      const res = Formula.convertToString({ K: 1, Mn: 1, O: 4 });
+      expect(res).toEqual('KMnO4');
+    });
   });
 
   describe('parse', () => {
@@ -61,6 +85,21 @@ describe('Formula', () => {
     it('should ignore unknown elements', () => {
       const res = Formula.parse('C2H5 OH X3');
       expect(res).toEqual({ C: 2, H: 6, O: 1 });
+    });
+
+    it('should parse multi-digit counts', () => {
+      const res = Formula.parse('C60');
+      expect(res).toEqual({ C: 60 });
+    });
+
+    it('should prefer two-letter elements over single-letter ones', () => {
+      const res = Formula.parse('CoO');
+      expect(res).toEqual({ Co: 1, O: 1 });
+    });
+
+    it('should sum repeated elements of CH3COOH', () => {
+      const res = Formula.parse('CH3COOH');
+      expect(res).toEqual({ C: 2, H: 4, O: 2 });
     });
   });
 });


### PR DESCRIPTION
PR3 of the prod-grade plan - the 70% thresholds in `vitest.config.ts` existed but never executed: CI ran `vitest run` without `--coverage`.

- Root `"test"` is now `vitest run --coverage` - every `npm test`, `npm run verify`, and both workflows enforce the gate (no workflow edits needed).
- `@chemistry/formula` branch coverage raised **68.2% -> 90.9%** in isolation via 9 real parser/Hill-notation cases (multi-digit counts `C60`, longest-match symbols `CoO`≠C+O, repeated-element accumulation `CH3COOH`, Hill ordering incl. no-carbon alphabetical path `KMnO4`/`H2O4S`). The 2 remaining uncovered branches are the comparator's equal-element paths, unreachable through the public API (`Object.keys` yields unique symbols) - covering them would be coverage-farming.

**Verified**
- Repo-wide: statements 99.58%, branches 98.06%, functions 100%.
- Gate proven live: threshold temporarily set to 99.9 -> `npm test` exit 1 with `ERROR: Coverage for branches (98.06%) does not meet global threshold (99.9%)`, then reverted.
- `npm run verify` exit 0 after rebase onto the v3.4.0 release commit.
- No other file is below 70% in isolation (math 99.25%/space-groups 97.1% branches are the next-lowest).
