### PR TITLE
ci: packaging validation - publint, attw, pack checks, consumer fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Package validation
+        run: npm run verify:pack

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -58,6 +58,11 @@ jobs:
         if: always() && steps.install.outcome == 'success'
         run: npm run build
 
+      - name: Package validation
+        id: verify-pack
+        if: always() && steps.install.outcome == 'success'
+        run: npm run verify:pack
+
       - name: Comment on PR
         if: always()
         uses: actions/github-script@v9
@@ -71,6 +76,7 @@ jobs:
               { name: 'Format check passed', outcome: '${{ steps.format.outcome }}' },
               { name: 'Tests passed', outcome: '${{ steps.test.outcome }}' },
               { name: 'Build successful', outcome: '${{ steps.build.outcome }}' },
+              { name: 'Package validation passed', outcome: '${{ steps.verify-pack.outcome }}' },
             ];
 
             const allPassed = checks.every(c => c.outcome === 'success');

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,12 @@
       ],
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
+        "@arethetypeswrong/cli": "^0.18.5",
         "@eslint/js": "^10.0.0",
         "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.8.0",
         "prettier": "^3.9.6",
+        "publint": "^0.3.23",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.66.0",
         "vitest": "^4.0.0"
@@ -25,6 +27,13 @@
         "node": ">=22.0.0",
         "npm": ">=10.0.0"
       }
+    },
+    "node_modules/@andrewbranch/untar.js": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.4.tgz",
+      "integrity": "sha512-pVXSwPsLuw8IGLo2Di0EaOfsk+ntVvpkk942J/sHYIkwvtKUakEcPh7HBgZ6tuimgzKSEHgCvO4XgQ05DEbwDw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.115.0",
@@ -46,6 +55,62 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@arethetypeswrong/cli": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.18.5.tgz",
+      "integrity": "sha512-gM+8vRsQOD/Uc7EnBedUhkG5OCsDWE4uoak5QvomGpMpaky0Eh41p04nIMgrWb8EOmqZUJGc6zz9hsP6E56R7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@arethetypeswrong/core": "0.18.5",
+        "chalk": "^4.1.2",
+        "cli-table3": "^0.6.3",
+        "commander": "^10.0.1",
+        "marked": "^9.1.2",
+        "marked-terminal": "^7.1.0",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "attw": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arethetypeswrong/core": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.5.tgz",
+      "integrity": "sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@andrewbranch/untar.js": "^1.0.3",
+        "@loaderkit/resolve": "^1.0.2",
+        "cjs-module-lexer": "^1.2.3",
+        "fflate": "^0.8.3",
+        "lru-cache": "^11.0.1",
+        "semver": "^7.5.4",
+        "typescript": "5.6.1-rc",
+        "validate-npm-package-name": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arethetypeswrong/core/node_modules/typescript": {
+      "version": "5.6.1-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
+      "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -118,6 +183,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@braidai/lang": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.2.tgz",
+      "integrity": "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@chemistry/common": {
       "resolved": "packages/common",
       "link": true
@@ -141,6 +213,17 @@
     "node_modules/@chemistry/space-groups": {
       "resolved": "packages/space-groups",
       "link": true
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
@@ -368,6 +451,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@loaderkit/resolve": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.6.tgz",
+      "integrity": "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@braidai/lang": "^1.0.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -395,6 +488,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@publint/pack": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.6.tgz",
+      "integrity": "sha512-3uVNyGcVplhPZSLVyeIpL7+cIRn1YCSNHLG/rUIlBQMVH8YuN9++YF+5+UDIIO9RW98dujiUoTltO7RDB5bFJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyexec": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -660,6 +769,19 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
@@ -955,6 +1077,58 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1010,6 +1184,120 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1061,12 +1349,49 @@
         "node": ">=8"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1282,6 +1607,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "dev": true,
@@ -1340,6 +1672,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "dev": true,
@@ -1359,6 +1701,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/html-escaper": {
@@ -1390,6 +1742,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -1778,6 +2140,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1816,6 +2188,54 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/marked": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.4.1",
+        "cli-highlight": "^2.1.11",
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.2.0",
+        "supports-hyperlinks": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=1 <16"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -1832,10 +2252,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
@@ -1860,6 +2302,32 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -1913,6 +2381,37 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -2010,6 +2509,28 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/publint": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.23.tgz",
+      "integrity": "sha512-5MQipUPcB7MWw84zLUkHrg/H/UBtk3LL+A0GngTTBSsiNJLQurMUaSIRG3edlOrRz4UFe0AOKK9TZdIWviV+jQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@publint/pack": "^0.1.6",
+        "package-manager-detector": "^1.7.0",
+        "picocolors": "^1.1.1",
+        "sade": "^1.8.1"
+      },
+      "bin": {
+        "publint": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -2021,6 +2542,16 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/rolldown": {
       "version": "1.1.5",
@@ -2054,6 +2585,19 @@
         "@rolldown/binding-wasm32-wasi": "1.1.5",
         "@rolldown/binding-win32-arm64-msvc": "1.1.5",
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/semver": {
@@ -2091,6 +2635,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "dev": true,
@@ -2122,6 +2679,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2135,13 +2730,55 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2432,12 +3069,32 @@
         "node": ">= 4"
       }
     },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/vite": {
@@ -2643,6 +3300,63 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -36,15 +36,18 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "tsc --noEmit",
-    "verify": "npm run type-check && npm run lint && npm run format:check && npm run test && npm run build",
+    "verify:pack": "node scripts/check-pack.js && tsc -p tools/consumer-check && node tools/consumer-check/smoke.mjs",
+    "verify": "npm run type-check && npm run lint && npm run format:check && npm run test && npm run build && npm run verify:pack",
     "clean": "rm -rf packages/*/dist coverage"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.115.0",
+    "@arethetypeswrong/cli": "^0.18.5",
     "@eslint/js": "^10.0.0",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.8.0",
     "prettier": "^3.9.6",
+    "publint": "^0.3.23",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.66.0",
     "vitest": "^4.0.0"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -49,6 +49,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "prepack": "rm -rf dist && tsc"
   }
 }

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -48,6 +48,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "prepack": "rm -rf dist && tsc"
   }
 }

--- a/packages/formula/package.json
+++ b/packages/formula/package.json
@@ -47,7 +47,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "prepack": "rm -rf dist && tsc"
   },
   "dependencies": {
     "@chemistry/elements": "^3.0.0"

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -47,7 +47,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "prepack": "rm -rf dist && tsc"
   },
   "dependencies": {
     "@chemistry/common": "^3.0.0"

--- a/packages/molecule/package.json
+++ b/packages/molecule/package.json
@@ -49,7 +49,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "prepack": "rm -rf dist && tsc"
   },
   "dependencies": {
     "@chemistry/common": "^3.0.0",

--- a/packages/space-groups/package.json
+++ b/packages/space-groups/package.json
@@ -50,6 +50,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "prepack": "rm -rf dist && tsc"
   }
 }

--- a/scripts/check-pack.js
+++ b/scripts/check-pack.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+/**
+ * check-pack.js
+ *
+ * Packaging validation for every published workspace: publint (strict),
+ * are-the-types-wrong (esm-only profile) and a sanity check of the tarball
+ * file list produced by `npm pack --dry-run --json`.
+ *
+ * Usage: node scripts/check-pack.js
+ */
+
+import { spawnSync } from 'child_process';
+import { readFileSync, existsSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+const binDir = join(rootDir, 'node_modules', '.bin');
+
+// Mirrors the root build/publish order so cross-package dist deps exist when prepack rebuilds
+const PUBLISH_ORDER = [
+  '@chemistry/common',
+  '@chemistry/elements',
+  '@chemistry/space-groups',
+  '@chemistry/math',
+  '@chemistry/formula',
+  '@chemistry/molecule',
+];
+
+const FORBIDDEN = [
+  { label: 'test file', match: (path) => /(^|\/)[^/]+\.test\.[^/]+$/.test(path) },
+  { label: 'snapshot', match: (path) => path.split('/').includes('__snapshots__') },
+  { label: 'tsx file', match: (path) => path.endsWith('.tsx') },
+];
+
+/**
+ * Expand simple glob pattern (e.g., "packages/*") to matching directories
+ */
+function expandGlobPattern(pattern) {
+  if (pattern.endsWith('/*')) {
+    const baseDir = join(rootDir, pattern.slice(0, -2));
+    if (!existsSync(baseDir)) return [];
+
+    return readdirSync(baseDir, { withFileTypes: true })
+      .filter((dirent) => dirent.isDirectory())
+      .map((dirent) => join(baseDir, dirent.name));
+  }
+
+  const fullPath = join(rootDir, pattern);
+  return existsSync(fullPath) ? [fullPath] : [];
+}
+
+/**
+ * Map publishable workspace name to its directory
+ */
+function discoverPackages() {
+  const rootManifest = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf8'));
+  const byName = new Map();
+
+  for (const dir of (rootManifest.workspaces || []).flatMap(expandGlobPattern)) {
+    const manifestPath = join(dir, 'package.json');
+    if (!existsSync(manifestPath)) continue;
+
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (manifest.private) continue;
+    byName.set(manifest.name, dir);
+  }
+
+  return byName;
+}
+
+function run(command, args, cwd) {
+  return spawnSync(command, args, { cwd, encoding: 'utf8' });
+}
+
+function fail(name, step, result, details = []) {
+  console.error(`\n✖ ${name} — ${step} failed`);
+  for (const detail of details) console.error(`  - ${detail}`);
+  const output = [result?.stdout, result?.stderr].filter(Boolean).join('\n').trim();
+  if (output) console.error(`\n${output}`);
+  process.exit(1);
+}
+
+/**
+ * Read the tarball file list; lifecycle script output may precede the JSON payload
+ */
+function packFileList(name) {
+  const result = run('npm', ['pack', '--dry-run', '--json', '-w', name], rootDir);
+  if (result.status !== 0) return { result, files: null };
+
+  const start = result.stdout.indexOf('[');
+  const end = result.stdout.lastIndexOf(']');
+  if (start === -1 || end === -1) return { result, files: null };
+
+  const parsed = JSON.parse(result.stdout.slice(start, end + 1));
+  return { result, files: parsed[0].files.map((entry) => entry.path) };
+}
+
+function inspectFileList(files) {
+  const problems = [];
+
+  if (!files.includes('LICENSE')) problems.push('LICENSE is missing');
+  if (!files.some((path) => path.startsWith('src/'))) problems.push('no src/ entries');
+
+  for (const rule of FORBIDDEN) {
+    const hits = files.filter(rule.match);
+    if (hits.length > 0) problems.push(`${rule.label} leaked: ${hits.join(', ')}`);
+  }
+
+  return problems;
+}
+
+function main() {
+  const packages = discoverPackages();
+  const missing = PUBLISH_ORDER.filter((name) => !packages.has(name));
+  if (missing.length > 0) throw new Error(`Unknown workspace(s): ${missing.join(', ')}`);
+
+  const extra = [...packages.keys()].filter((name) => !PUBLISH_ORDER.includes(name));
+  if (extra.length > 0) throw new Error(`Not in PUBLISH_ORDER: ${extra.join(', ')}`);
+
+  console.log(`Validating ${PUBLISH_ORDER.length} packages...\n`);
+
+  for (const name of PUBLISH_ORDER) {
+    const dir = packages.get(name);
+
+    const publint = run(join(binDir, 'publint'), ['run', '--strict'], dir);
+    if (publint.status !== 0) fail(name, 'publint', publint);
+
+    const attw = run(join(binDir, 'attw'), ['--pack', '--profile', 'esm-only', '.'], dir);
+    if (attw.status !== 0) fail(name, 'attw', attw);
+
+    const { result, files } = packFileList(name);
+    if (files === null) fail(name, 'npm pack', result);
+
+    const problems = inspectFileList(files);
+    if (problems.length > 0) fail(name, 'pack file list', null, problems);
+
+    console.log(`✔ ${name} — publint ok · attw ok · ${files.length} packed files, no leaks`);
+  }
+
+  console.log('\nPackage validation passed.');
+}
+
+main();

--- a/tools/consumer-check/consumer.ts
+++ b/tools/consumer-check/consumer.ts
@@ -1,0 +1,45 @@
+// No tsconfig paths here on purpose: a NodeNext consumer must resolve through the published exports maps.
+import { EPSILON } from '@chemistry/common';
+import type { JNMol } from '@chemistry/common';
+import { ChemElements } from '@chemistry/elements';
+import type { ChemElementInfo } from '@chemistry/elements';
+import { Formula } from '@chemistry/formula';
+import type { ChemComposition } from '@chemistry/formula';
+import { Quaternion, Vec3 } from '@chemistry/math';
+import { defaultSvgOptions, exportToSVG, Molecule, MoleculeDataFormat } from '@chemistry/molecule';
+import { CrystalSystem, SpaceGroup } from '@chemistry/space-groups';
+import type { SpaceGroupInfo } from '@chemistry/space-groups';
+
+const epsilon: number = EPSILON;
+
+const carbon: ChemElementInfo | null = ChemElements.getBySymbol('C');
+const symbols: string[] = ChemElements.getAllSymbols();
+
+const water: ChemComposition = Formula.parse('H2O');
+const weight: number = Formula.convertToWeight(water);
+
+const axis: Vec3 = Vec3.cross(new Vec3(1, 0, 0), new Vec3(0, 1, 0));
+const dot: number = Vec3.dot(axis, axis);
+const rotation: Quaternion = new Quaternion(0, 0, 0, 1);
+
+const data: JNMol = { id: 'm1', title: 'empty', atoms: {}, bonds: {} };
+const molecule = new Molecule();
+molecule.load(data, MoleculeDataFormat.jnmol);
+const atomCount: number = molecule.getAtomCount();
+const svg: string = exportToSVG(molecule.export(MoleculeDataFormat.jnmol), defaultSvgOptions);
+
+const group: SpaceGroupInfo | null = SpaceGroup.getById(1);
+const system: CrystalSystem | null = group ? SpaceGroup.getCrystalSystem(group) : null;
+
+export const summary = {
+  epsilon,
+  carbon,
+  symbols,
+  weight,
+  dot,
+  rotation,
+  atomCount,
+  svg,
+  group,
+  system,
+};

--- a/tools/consumer-check/smoke.mjs
+++ b/tools/consumer-check/smoke.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+/**
+ * smoke.mjs
+ *
+ * Runtime counterpart to consumer.ts: imports every published package by bare
+ * specifier through the real exports map and asserts the barrel symbols exist.
+ *
+ * Usage: node tools/consumer-check/smoke.mjs
+ */
+
+import assert from 'node:assert/strict';
+
+const EXPECTED = [
+  ['@chemistry/common', { EPSILON: 'number' }],
+  ['@chemistry/elements', { ChemElements: 'function', ChemElementData: 'object' }],
+  ['@chemistry/formula', { Formula: 'function' }],
+  ['@chemistry/math', { Vec3: 'function', Quaternion: 'function' }],
+  [
+    '@chemistry/molecule',
+    { Molecule: 'function', exportToSVG: 'function', defaultSvgOptions: 'object' },
+  ],
+  ['@chemistry/space-groups', { SpaceGroup: 'function', SpaceGroupsData: 'object' }],
+];
+
+for (const [specifier, symbols] of EXPECTED) {
+  const mod = await import(specifier);
+
+  for (const [name, kind] of Object.entries(symbols)) {
+    assert.equal(
+      typeof mod[name],
+      kind,
+      `${specifier}: expected export "${name}" to be a ${kind}, got ${typeof mod[name]}`
+    );
+  }
+
+  console.log(`✔ ${specifier} — ${Object.keys(symbols).join(', ')}`);
+}
+
+console.log('\nConsumer smoke passed.');

--- a/tools/consumer-check/tsconfig.json
+++ b/tools/consumer-check/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": []
+  },
+  "include": ["consumer.ts"]
+}


### PR DESCRIPTION
PR4 of the prod-grade plan - CI can now catch a broken exports map, missing types, stale/empty dist, or tarball leaks before publish.

**New gates (all in `verify:pack`, wired into `verify` + both workflows):**
- `publint` (strict) + `attw --pack` (esm-only profile) + pack file-list leak check (LICENSE/src present, zero test/snapshot/tsx entries) per package, via `scripts/check-pack.js` running in publish order.
- NodeNext consumer fixture `tools/consumer-check/`: `tsc` typecheck + runtime `smoke.mjs`, both resolving all 6 packages by bare specifier through root node_modules symlinks and the REAL exports maps (no `paths` aliases).
- `prepack: rm -rf dist && tsc` in all 6 manifests - any pack/publish rebuilds fresh, killing the stale-dist failure mode at the source.

**Proven with injected breaks (reverted):**
- `types` -> nonexistent file: publint exit 1 (`file does not exist`), attw independently flags it; tsc alone would have passed.
- `import` -> nonexistent file: publint exit 1; with publint bypassed only the runtime smoke catches it (attw + tsc pass) - the three layers are non-redundant.

**Verified:** full `npm run verify` exit 0 (212 tests); `verify:pack` adds 11s (18s total); lockfile regenerated with npm@10 for CI parity; `npm ci --dry-run` clean under npm 10.

**Flagged for PR7, not fixed here:** publint suggestion `repository.url` should use `git+https://` prefix (all 6); `IMoleculeState` appears in `exportToSVG`'s public signature but isn't exported from molecule's barrel.
