### PR TITLE
ci: fail-closed prod audit, Node 22/24 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,32 @@ on:
 
 jobs:
   build:
+    name: Build (Node.js ${{ matrix.node }}.x)
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22, 24]
 
     steps:
       - uses: actions/checkout@v7
 
-      - name: Use Node.js 22.x
+      - name: Use Node.js ${{ matrix.node }}.x
         uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: ${{ matrix.node }}.x
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Security audit (production dependencies)
+        run: npm audit --omit=dev --audit-level=low
+
+      - name: Security audit (all dependencies, informational)
+        continue-on-error: true
+        run: npm audit
 
       - name: Type check
         run: npm run type-check

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,9 +15,14 @@ permissions:
 
 jobs:
   validate:
-    name: Validate Pull Request
+    name: Validate Pull Request (Node.js ${{ matrix.node }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22, 24]
 
     steps:
       - name: Checkout code
@@ -26,12 +31,23 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '${{ matrix.node }}'
           cache: 'npm'
 
       - name: Install dependencies
         id: install
         run: npm ci
+
+      - name: Security audit (production dependencies)
+        id: audit-prod
+        if: always() && steps.install.outcome == 'success'
+        run: npm audit --omit=dev --audit-level=low
+
+      - name: Security audit (all dependencies, informational)
+        id: audit-all
+        if: always() && steps.install.outcome == 'success'
+        continue-on-error: true
+        run: npm audit
 
       - name: Type check
         id: type-check
@@ -64,13 +80,14 @@ jobs:
         run: npm run verify:pack
 
       - name: Comment on PR
-        if: always()
+        if: always() && matrix.node == 22
         uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- pr-validation-bot -->';
             const checks = [
               { name: 'Dependencies installed', outcome: '${{ steps.install.outcome }}' },
+              { name: 'Production dependency audit passed', outcome: '${{ steps.audit-prod.outcome }}' },
               { name: 'Type check passed', outcome: '${{ steps.type-check.outcome }}' },
               { name: 'Linting passed', outcome: '${{ steps.lint.outcome }}' },
               { name: 'Format check passed', outcome: '${{ steps.format.outcome }}' },
@@ -88,15 +105,16 @@ jobs:
               .join('\n');
 
             const body = `${marker}
-            ${emoji} **PR Validation ${status}**
+            ${emoji} **PR Validation ${status}** (Node.js 22)
 
             **Commit:** \`${{ github.event.pull_request.head.sha }}\`
             **Branch:** \`${{ github.head_ref }}\`
+            **Node.js:** \`22\` (the Node.js 24 leg reports separately in the checks list)
 
             **Checks:**
             ${checkLines}
 
-            ${allPassed ? '**Ready to merge!** ✨' : '**Please fix the failing checks.**'}
+            ${allPassed ? '**Node.js 22 checks passed!** Confirm the Node.js 24 job before merging. ✨' : '**Please fix the failing checks.**'}
 
             ---
             🔗 [View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
PR5 of the prod-grade plan - CI previously had zero security scanning and tested a single Node version.

- **Security audit, two lanes**: `npm audit --omit=dev --audit-level=low` fail-closed (prod tree is currently 0 vulns, so this lands green); full `npm audit` as a second informational step with `continue-on-error` (currently 3 dev-only advisories: flatted, nanoid, postcss - visible in logs, non-blocking).
- **Node [22, 24] matrix** on both workflows, `fail-fast: false`; sticky PR comment gated to the Node 22 leg (its success line now says to confirm the Node 24 job) with a new "Production dependency audit passed" check line.

**Notes**
- Status-check names change (`Validate Pull Request` -> `Validate Pull Request (Node.js 22/24)`); no branch protection or rulesets exist on master (verified via API), so nothing pins the old names.
- `concurrency` is workflow-level, so `cancel-in-progress` still cancels whole runs - the two matrix legs cannot cancel each other (verified by parse).
- engine-strict + npm 11 on Node 24 verified locally: `npm ci --dry-run` + full `npm run verify` green on node 24.6.0/npm 11.7.0.
