### PR TITLE
chore: lint+test release scripts, fix AI changelog silent fallback

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -135,7 +135,7 @@ jobs:
           set -uo pipefail
           VERSION="${{ steps.bump.outputs.version }}"
           # AI changelog is best-effort; fall back to git subjects so the train never blocks on a missing key.
-          if ! CHANGELOG=$(node scripts/generate-changelog.js "$VERSION" 2>/dev/null); then
+          if ! CHANGELOG=$(node scripts/generate-changelog.js "$VERSION"); then
             CHANGELOG=""
           fi
           if [ -z "$CHANGELOG" ] || [ "$CHANGELOG" = "No significant changes" ]; then

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,18 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ['dist/', 'node_modules/', 'coverage/', 'scripts/'],
+    files: ['scripts/**/*.js'],
+    extends: [tseslint.configs.disableTypeChecked],
+    languageOptions: {
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        setTimeout: 'readonly',
+        URL: 'readonly',
+      },
+    },
+  },
+  {
+    ignores: ['dist/', 'node_modules/', 'coverage/'],
   }
 );

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prebuild": "rm -rf packages/*/dist",
     "build": "npm run build -w @chemistry/common -w @chemistry/elements -w @chemistry/space-groups && npm run build -w @chemistry/math -w @chemistry/formula && npm run build -w @chemistry/molecule",
     "test": "vitest run --coverage",
-    "lint": "eslint packages/*/src/",
+    "lint": "eslint packages/*/src/ scripts/",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "tsc --noEmit",

--- a/scripts/bump-versions.js
+++ b/scripts/bump-versions.js
@@ -11,7 +11,7 @@
 
 import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
@@ -19,26 +19,30 @@ const rootDir = join(__dirname, '..');
 /**
  * Expand simple glob pattern (e.g., "packages/*") to matching directories
  */
-function expandGlobPattern(pattern) {
+export function expandGlobPattern(pattern, root = rootDir) {
   if (pattern.endsWith('/*')) {
-    const baseDir = join(rootDir, pattern.slice(0, -2));
-    if (!existsSync(baseDir)) return [];
+    const baseDir = join(root, pattern.slice(0, -2));
+    if (!existsSync(baseDir)) {
+      return [];
+    }
 
     return readdirSync(baseDir, { withFileTypes: true })
       .filter((dirent) => dirent.isDirectory())
       .map((dirent) => join(baseDir, dirent.name));
   }
 
-  const fullPath = join(rootDir, pattern);
+  const fullPath = join(root, pattern);
   return existsSync(fullPath) ? [fullPath] : [];
 }
 
 /**
  * Parse semver version string
  */
-function parseVersion(version) {
+export function parseVersion(version) {
   const match = version.match(/^(\d+)\.(\d+)\.(\d+)(-.*)?$/);
-  if (!match) throw new Error(`Invalid version: ${version}`);
+  if (!match) {
+    throw new Error(`Invalid version: ${version}`);
+  }
   return {
     major: parseInt(match[1], 10),
     minor: parseInt(match[2], 10),
@@ -50,7 +54,7 @@ function parseVersion(version) {
 /**
  * Bump version based on type
  */
-function bumpVersion(version, type) {
+export function bumpVersion(version, type) {
   const v = parseVersion(version);
   switch (type) {
     case 'major':
@@ -66,7 +70,7 @@ function bumpVersion(version, type) {
 /**
  * Check if package is in main version series (3.x.x)
  */
-function isMainVersionSeries(version) {
+export function isMainVersionSeries(version) {
   const v = parseVersion(version);
   return v.major === 3;
 }
@@ -74,8 +78,8 @@ function isMainVersionSeries(version) {
 /**
  * Get all workspace packages from root package.json
  */
-function getWorkspacePackages() {
-  const rootPkgPath = join(rootDir, 'package.json');
+export function getWorkspacePackages(root = rootDir) {
+  const rootPkgPath = join(root, 'package.json');
   const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf-8'));
 
   const packages = [];
@@ -90,7 +94,7 @@ function getWorkspacePackages() {
   const workspaces = rootPkg.workspaces || [];
 
   for (const pattern of workspaces) {
-    const dirs = expandGlobPattern(pattern);
+    const dirs = expandGlobPattern(pattern, root);
 
     for (const dir of dirs) {
       const pkgPath = join(dir, 'package.json');
@@ -113,7 +117,7 @@ function getWorkspacePackages() {
 /**
  * Update version in package.json file
  */
-function updatePackageVersion(pkgPath, newVersion) {
+export function updatePackageVersion(pkgPath, newVersion) {
   const content = readFileSync(pkgPath, 'utf-8');
   const pkg = JSON.parse(content);
   const oldVersion = pkg.version;
@@ -124,7 +128,7 @@ function updatePackageVersion(pkgPath, newVersion) {
   return { oldVersion, newVersion };
 }
 
-function main() {
+export function main() {
   const bumpType = process.argv[2] || 'patch';
 
   if (!['patch', 'minor', 'major'].includes(bumpType)) {
@@ -177,9 +181,14 @@ function main() {
   console.log(`NEW_VERSION=${newVersion}`);
 }
 
-try {
-  main();
-} catch (err) {
-  console.error('Error:', err.message);
-  process.exit(1);
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exit(1);
+  }
 }

--- a/scripts/bump-versions.test.js
+++ b/scripts/bump-versions.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  parseVersion,
+  bumpVersion,
+  isMainVersionSeries,
+  expandGlobPattern,
+  getWorkspacePackages,
+  updatePackageVersion,
+} from './bump-versions.js';
+
+function writeManifest(dir, manifest) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest, null, 2) + '\n');
+}
+
+describe('parseVersion', () => {
+  it('parses a plain semver version', () => {
+    expect(parseVersion('3.4.0')).toEqual({ major: 3, minor: 4, patch: 0, prerelease: '' });
+  });
+
+  it('parses a prerelease suffix', () => {
+    expect(parseVersion('1.2.3-beta.1').prerelease).toBe('-beta.1');
+  });
+
+  it('throws on a non-semver string', () => {
+    expect(() => parseVersion('3.4')).toThrow('Invalid version: 3.4');
+  });
+});
+
+describe('bumpVersion', () => {
+  it('bumps the patch segment', () => {
+    expect(bumpVersion('3.4.0', 'patch')).toBe('3.4.1');
+  });
+
+  it('bumps minor and resets patch', () => {
+    expect(bumpVersion('3.4.7', 'minor')).toBe('3.5.0');
+  });
+
+  it('bumps major and resets minor and patch', () => {
+    expect(bumpVersion('3.4.7', 'major')).toBe('4.0.0');
+  });
+
+  it('falls back to a patch bump for an unknown type', () => {
+    expect(bumpVersion('3.4.7', 'auto')).toBe('3.4.8');
+  });
+
+  it('drops the prerelease suffix when bumping', () => {
+    expect(bumpVersion('3.4.0-rc.1', 'patch')).toBe('3.4.1');
+  });
+});
+
+describe('isMainVersionSeries', () => {
+  it('accepts the 3.x series', () => {
+    expect(isMainVersionSeries('3.0.0')).toBe(true);
+  });
+
+  it('rejects other majors', () => {
+    expect(isMainVersionSeries('2.9.9')).toBe(false);
+    expect(isMainVersionSeries('4.0.0')).toBe(false);
+  });
+});
+
+describe('workspace discovery against a fixture monorepo', () => {
+  let root;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'bump-versions-'));
+    writeManifest(root, {
+      name: 'root',
+      version: '3.4.0',
+      private: true,
+      workspaces: ['packages/*'],
+    });
+    writeManifest(join(root, 'packages', 'alpha'), { name: '@fixture/alpha', version: '3.4.0' });
+    writeManifest(join(root, 'packages', 'beta'), { name: '@fixture/beta', version: '3.4.0' });
+    writeManifest(join(root, 'packages', 'legacy'), { name: '@fixture/legacy', version: '2.1.0' });
+    writeFileSync(join(root, 'packages', 'stray.txt'), 'not a package');
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('expands a trailing-star pattern to directories only', () => {
+    const dirs = expandGlobPattern('packages/*', root).map((dir) => dir.replace(root, ''));
+    expect(dirs.sort()).toEqual(['/packages/alpha', '/packages/beta', '/packages/legacy']);
+  });
+
+  it('returns an empty list for a missing base directory', () => {
+    expect(expandGlobPattern('missing/*', root)).toEqual([]);
+  });
+
+  it('collects the root manifest plus every workspace package', () => {
+    const packages = getWorkspacePackages(root);
+    expect(packages[0].isRoot).toBe(true);
+    expect(packages.map((pkg) => pkg.name).sort()).toEqual([
+      '@fixture/alpha',
+      '@fixture/beta',
+      '@fixture/legacy',
+      'root',
+    ]);
+  });
+
+  it('rewrites only the version of a manifest', () => {
+    const pkgPath = join(root, 'packages', 'alpha', 'package.json');
+    const result = updatePackageVersion(pkgPath, '3.5.0');
+
+    expect(result).toEqual({ oldVersion: '3.4.0', newVersion: '3.5.0' });
+
+    const raw = readFileSync(pkgPath, 'utf-8');
+    expect(JSON.parse(raw)).toEqual({ name: '@fixture/alpha', version: '3.5.0' });
+    expect(raw.endsWith('\n')).toBe(true);
+  });
+
+  it('bumps every main-series package and leaves off-series ones alone', () => {
+    const packages = getWorkspacePackages(root);
+    const mainPackages = packages.filter((pkg) => isMainVersionSeries(pkg.version));
+    const newVersion = bumpVersion(mainPackages[0].version, 'minor');
+
+    for (const pkg of mainPackages) {
+      updatePackageVersion(pkg.path, newVersion);
+    }
+
+    const read = (name) =>
+      JSON.parse(readFileSync(join(root, 'packages', name, 'package.json'), 'utf-8')).version;
+
+    expect(mainPackages).toHaveLength(3);
+    expect(read('alpha')).toBe('3.5.0');
+    expect(read('beta')).toBe('3.5.0');
+    expect(read('legacy')).toBe('2.1.0');
+  });
+});

--- a/scripts/check-pack.js
+++ b/scripts/check-pack.js
@@ -41,7 +41,9 @@ const FORBIDDEN = [
 function expandGlobPattern(pattern) {
   if (pattern.endsWith('/*')) {
     const baseDir = join(rootDir, pattern.slice(0, -2));
-    if (!existsSync(baseDir)) return [];
+    if (!existsSync(baseDir)) {
+      return [];
+    }
 
     return readdirSync(baseDir, { withFileTypes: true })
       .filter((dirent) => dirent.isDirectory())
@@ -61,10 +63,14 @@ function discoverPackages() {
 
   for (const dir of (rootManifest.workspaces || []).flatMap(expandGlobPattern)) {
     const manifestPath = join(dir, 'package.json');
-    if (!existsSync(manifestPath)) continue;
+    if (!existsSync(manifestPath)) {
+      continue;
+    }
 
     const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-    if (manifest.private) continue;
+    if (manifest.private) {
+      continue;
+    }
     byName.set(manifest.name, dir);
   }
 
@@ -77,9 +83,13 @@ function run(command, args, cwd) {
 
 function fail(name, step, result, details = []) {
   console.error(`\n✖ ${name} — ${step} failed`);
-  for (const detail of details) console.error(`  - ${detail}`);
+  for (const detail of details) {
+    console.error(`  - ${detail}`);
+  }
   const output = [result?.stdout, result?.stderr].filter(Boolean).join('\n').trim();
-  if (output) console.error(`\n${output}`);
+  if (output) {
+    console.error(`\n${output}`);
+  }
   process.exit(1);
 }
 
@@ -88,11 +98,15 @@ function fail(name, step, result, details = []) {
  */
 function packFileList(name) {
   const result = run('npm', ['pack', '--dry-run', '--json', '-w', name], rootDir);
-  if (result.status !== 0) return { result, files: null };
+  if (result.status !== 0) {
+    return { result, files: null };
+  }
 
   const start = result.stdout.indexOf('[');
   const end = result.stdout.lastIndexOf(']');
-  if (start === -1 || end === -1) return { result, files: null };
+  if (start === -1 || end === -1) {
+    return { result, files: null };
+  }
 
   const parsed = JSON.parse(result.stdout.slice(start, end + 1));
   return { result, files: parsed[0].files.map((entry) => entry.path) };
@@ -101,12 +115,18 @@ function packFileList(name) {
 function inspectFileList(files) {
   const problems = [];
 
-  if (!files.includes('LICENSE')) problems.push('LICENSE is missing');
-  if (!files.some((path) => path.startsWith('src/'))) problems.push('no src/ entries');
+  if (!files.includes('LICENSE')) {
+    problems.push('LICENSE is missing');
+  }
+  if (!files.some((path) => path.startsWith('src/'))) {
+    problems.push('no src/ entries');
+  }
 
   for (const rule of FORBIDDEN) {
     const hits = files.filter(rule.match);
-    if (hits.length > 0) problems.push(`${rule.label} leaked: ${hits.join(', ')}`);
+    if (hits.length > 0) {
+      problems.push(`${rule.label} leaked: ${hits.join(', ')}`);
+    }
   }
 
   return problems;
@@ -115,10 +135,14 @@ function inspectFileList(files) {
 function main() {
   const packages = discoverPackages();
   const missing = PUBLISH_ORDER.filter((name) => !packages.has(name));
-  if (missing.length > 0) throw new Error(`Unknown workspace(s): ${missing.join(', ')}`);
+  if (missing.length > 0) {
+    throw new Error(`Unknown workspace(s): ${missing.join(', ')}`);
+  }
 
   const extra = [...packages.keys()].filter((name) => !PUBLISH_ORDER.includes(name));
-  if (extra.length > 0) throw new Error(`Not in PUBLISH_ORDER: ${extra.join(', ')}`);
+  if (extra.length > 0) {
+    throw new Error(`Not in PUBLISH_ORDER: ${extra.join(', ')}`);
+  }
 
   console.log(`Validating ${PUBLISH_ORDER.length} packages...\n`);
 
@@ -126,16 +150,24 @@ function main() {
     const dir = packages.get(name);
 
     const publint = run(join(binDir, 'publint'), ['run', '--strict'], dir);
-    if (publint.status !== 0) fail(name, 'publint', publint);
+    if (publint.status !== 0) {
+      fail(name, 'publint', publint);
+    }
 
     const attw = run(join(binDir, 'attw'), ['--pack', '--profile', 'esm-only', '.'], dir);
-    if (attw.status !== 0) fail(name, 'attw', attw);
+    if (attw.status !== 0) {
+      fail(name, 'attw', attw);
+    }
 
     const { result, files } = packFileList(name);
-    if (files === null) fail(name, 'npm pack', result);
+    if (files === null) {
+      fail(name, 'npm pack', result);
+    }
 
     const problems = inspectFileList(files);
-    if (problems.length > 0) fail(name, 'pack file list', null, problems);
+    if (problems.length > 0) {
+      fail(name, 'pack file list', null, problems);
+    }
 
     console.log(`✔ ${name} — publint ok · attw ok · ${files.length} packed files, no leaks`);
   }

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -15,8 +15,12 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { execSync } from 'child_process';
+import { pathToFileURL } from 'url';
 
-const CHANGELOG_PROMPT = `You are a changelog generator for @chemistry/* — a set of open-source cheminformatics libraries for JavaScript.
+const MODEL = 'claude-sonnet-5';
+const MAX_TOKENS = 8192;
+
+export const CHANGELOG_PROMPT = `You are a changelog generator for @chemistry/* — a set of open-source cheminformatics libraries for JavaScript.
 The monorepo contains packages: @chemistry/common, @chemistry/elements, @chemistry/formula, @chemistry/math, @chemistry/molecule, @chemistry/space-groups.
 
 Given the following git commits, generate a concise, user-friendly changelog entry.
@@ -52,9 +56,27 @@ Commits to analyze:
 `;
 
 /**
+ * Build the full prompt sent to Claude for a set of commit lines
+ */
+export function buildChangelogPrompt(commits) {
+  return CHANGELOG_PROMPT + '\n```\n' + commits + '\n```';
+}
+
+/**
+ * Join the text blocks of an API response into a single string
+ */
+export function extractTextContent(message) {
+  return message.content
+    .filter((block) => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n')
+    .trim();
+}
+
+/**
  * Get commits since the last tag
  */
-function getCommitsSinceLastTag() {
+export function getCommitsSinceLastTag() {
   try {
     const lastTag = execSync('git describe --tags --abbrev=0 2>/dev/null || echo ""', {
       encoding: 'utf-8',
@@ -88,37 +110,31 @@ function getCommitsSinceLastTag() {
 /**
  * Generate changelog using Claude API
  */
-async function generateChangelog(commits, version) {
-  if (!process.env.ANTHROPIC_API_KEY) {
-    throw new Error('ANTHROPIC_API_KEY environment variable is required');
-  }
-
+export async function generateChangelog(commits, client = new Anthropic()) {
   if (!commits || commits.trim() === '') {
     return 'No significant changes';
   }
 
-  const client = new Anthropic();
-
   const message = await client.messages.create({
-    model: 'claude-sonnet-4-20250514',
-    max_tokens: 1024,
+    model: MODEL,
+    max_tokens: MAX_TOKENS,
     messages: [
       {
         role: 'user',
-        content: CHANGELOG_PROMPT + '\n```\n' + commits + '\n```',
+        content: buildChangelogPrompt(commits),
       },
     ],
   });
 
-  const content = message.content
-    .filter((block) => block.type === 'text')
-    .map((block) => block.text)
-    .join('\n');
-
-  return content.trim();
+  return extractTextContent(message);
 }
 
-async function main() {
+export async function main() {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('ANTHROPIC_API_KEY not set - cannot generate AI changelog');
+    process.exit(1);
+  }
+
   const version = process.argv[2];
 
   if (!version) {
@@ -144,16 +160,26 @@ async function main() {
   console.error('Calling Claude API...');
 
   try {
-    const changelog = await generateChangelog(commits, version);
+    const changelog = await generateChangelog(commits);
     console.error('');
     console.error('Generated changelog:');
     console.error('---');
 
     console.log(changelog);
   } catch (error) {
-    console.error('Error generating changelog:', error.message);
+    console.error('Error generating changelog:');
+    console.error(`  name: ${error?.name ?? 'Error'}`);
+    if (error?.status !== undefined) {
+      console.error(`  status: ${error.status}`);
+    }
+    console.error(`  message: ${error?.message ?? String(error)}`);
     process.exit(1);
   }
 }
 
-main();
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  await main();
+}

--- a/scripts/generate-changelog.test.js
+++ b/scripts/generate-changelog.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CHANGELOG_PROMPT,
+  buildChangelogPrompt,
+  extractTextContent,
+  generateChangelog,
+} from './generate-changelog.js';
+
+function fakeClient(blocks) {
+  const calls = [];
+  return {
+    calls,
+    messages: {
+      create: (params) => {
+        calls.push(params);
+        return Promise.resolve({ content: blocks });
+      },
+    },
+  };
+}
+
+describe('buildChangelogPrompt', () => {
+  it('wraps the commits in a fenced block after the prompt', () => {
+    const prompt = buildChangelogPrompt('abc123 feat: add a thing');
+
+    expect(prompt.startsWith(CHANGELOG_PROMPT)).toBe(true);
+    expect(prompt).toContain('```\nabc123 feat: add a thing\n```');
+  });
+
+  it('names the published packages so the model can group by them', () => {
+    expect(buildChangelogPrompt('')).toContain('@chemistry/formula');
+  });
+});
+
+describe('extractTextContent', () => {
+  it('joins text blocks and trims the result', () => {
+    const message = { content: [{ type: 'text', text: '  ### Bug Fixes\n- Fix a thing  ' }] };
+    expect(extractTextContent(message)).toBe('### Bug Fixes\n- Fix a thing');
+  });
+
+  it('ignores non-text blocks', () => {
+    const message = {
+      content: [
+        { type: 'thinking', thinking: 'ignore me' },
+        { type: 'text', text: '### New Features' },
+        { type: 'text', text: '- Add a thing' },
+      ],
+    };
+    expect(extractTextContent(message)).toBe('### New Features\n- Add a thing');
+  });
+});
+
+describe('generateChangelog', () => {
+  it('short-circuits without calling the API when there are no commits', async () => {
+    const client = fakeClient([]);
+
+    expect(await generateChangelog('', client)).toBe('No significant changes');
+    expect(await generateChangelog('   ', client)).toBe('No significant changes');
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it('returns the model text for a set of commits', async () => {
+    const client = fakeClient([{ type: 'text', text: '### Bug Fixes\n- Fix a thing' }]);
+
+    expect(await generateChangelog('abc123 fix: a thing', client)).toBe(
+      '### Bug Fixes\n- Fix a thing'
+    );
+  });
+
+  it('requests a current model with enough room for a changelog', async () => {
+    const client = fakeClient([{ type: 'text', text: 'ok' }]);
+
+    await generateChangelog('abc123 fix: a thing', client);
+
+    const [params] = client.calls;
+    expect(params.model).toBe('claude-sonnet-5');
+    expect(params.max_tokens).toBeGreaterThanOrEqual(4096);
+    expect(params.messages).toEqual([
+      { role: 'user', content: buildChangelogPrompt('abc123 fix: a thing') },
+    ]);
+  });
+
+  it('sends no sampling parameters (claude-sonnet-5 rejects non-default values)', async () => {
+    const client = fakeClient([{ type: 'text', text: 'ok' }]);
+
+    await generateChangelog('abc123 fix: a thing', client);
+
+    const [params] = client.calls;
+    expect(params).not.toHaveProperty('temperature');
+    expect(params).not.toHaveProperty('top_p');
+    expect(params).not.toHaveProperty('top_k');
+    expect(params).not.toHaveProperty('thinking');
+  });
+
+  it('propagates API failures to the caller', async () => {
+    const client = {
+      messages: {
+        create: () => Promise.reject(Object.assign(new Error('bad key'), { status: 401 })),
+      },
+    };
+
+    await expect(generateChangelog('abc123 fix: a thing', client)).rejects.toThrow('bad key');
+  });
+});

--- a/scripts/update-changelog.js
+++ b/scripts/update-changelog.js
@@ -12,7 +12,7 @@
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
@@ -21,7 +21,7 @@ const changelogPath = join(rootDir, 'CHANGELOG.md');
 /**
  * Get today's date in YYYY-MM-DD format
  */
-function getToday() {
+export function getToday() {
   const now = new Date();
   const year = now.getFullYear();
   const month = String(now.getMonth() + 1).padStart(2, '0');
@@ -32,7 +32,7 @@ function getToday() {
 /**
  * Create initial CHANGELOG.md if it doesn't exist
  */
-function createInitialChangelog() {
+export function createInitialChangelog(targetPath = changelogPath) {
   const content = `# Changelog
 
 All notable changes to @chemistry/* libraries will be documented in this file.
@@ -43,20 +43,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 
 `;
-  writeFileSync(changelogPath, content);
+  writeFileSync(targetPath, content);
   return content;
 }
 
 /**
  * Insert new entry into changelog
  */
-function insertChangelogEntry(version, content) {
+export function insertChangelogEntry(version, content, targetPath = changelogPath) {
   let changelog;
 
-  if (existsSync(changelogPath)) {
-    changelog = readFileSync(changelogPath, 'utf-8');
+  if (existsSync(targetPath)) {
+    changelog = readFileSync(targetPath, 'utf-8');
   } else {
-    changelog = createInitialChangelog();
+    changelog = createInitialChangelog(targetPath);
   }
 
   const date = getToday();
@@ -71,12 +71,13 @@ ${content}
     console.error(`Warning: Version ${version} already exists in CHANGELOG.md`);
     console.error('Updating existing entry...');
 
+    // Entry body runs to the next version heading, or to end of file when it is the last entry
     const entryPattern = new RegExp(
-      `## \\[${version.replace(/\./g, '\\.')}\\][^]*?(?=## \\[|---|\$)`,
+      `^## \\[${version.replace(/\./g, '\\.')}\\][^]*?(?=^## \\[|(?![^]))`,
       'm'
     );
-    const updatedContent = changelog.replace(entryPattern, newEntry);
-    writeFileSync(changelogPath, updatedContent);
+    const updatedContent = changelog.replace(entryPattern, () => newEntry);
+    writeFileSync(targetPath, updatedContent);
     return;
   }
 
@@ -89,7 +90,7 @@ ${content}
     const after = changelog.slice(insertPosition).replace(/^\n+/, '');
 
     const newChangelog = before + '\n' + newEntry + after;
-    writeFileSync(changelogPath, newChangelog);
+    writeFileSync(targetPath, newChangelog);
   } else {
     const firstEntryMatch = changelog.match(/^## \[/m);
     if (firstEntryMatch) {
@@ -97,10 +98,10 @@ ${content}
       const before = changelog.slice(0, insertPosition);
       const after = changelog.slice(insertPosition);
       const newChangelog = before + newEntry + after;
-      writeFileSync(changelogPath, newChangelog);
+      writeFileSync(targetPath, newChangelog);
     } else {
       const newChangelog = changelog + '\n' + newEntry;
-      writeFileSync(changelogPath, newChangelog);
+      writeFileSync(targetPath, newChangelog);
     }
   }
 }
@@ -134,7 +135,7 @@ async function readStdin() {
   });
 }
 
-async function main() {
+export async function main() {
   const version = process.argv[2];
   let content = process.argv[3];
 
@@ -165,7 +166,12 @@ async function main() {
   console.log(`Date: ${getToday()}`);
 }
 
-main().catch((err) => {
-  console.error('Error:', err.message);
-  process.exit(1);
-});
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('Error:', err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/update-changelog.test.js
+++ b/scripts/update-changelog.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getToday, createInitialChangelog, insertChangelogEntry } from './update-changelog.js';
+
+const HEADER = `# Changelog
+
+All notable changes to @chemistry/* libraries will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+`;
+
+describe('getToday', () => {
+  it('formats the current date as YYYY-MM-DD', () => {
+    expect(getToday()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe('insertChangelogEntry', () => {
+  let dir;
+  let path;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'update-changelog-'));
+    path = join(dir, 'CHANGELOG.md');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('creates the file with a header when it does not exist', () => {
+    expect(existsSync(path)).toBe(false);
+
+    insertChangelogEntry('3.4.1', '### Bug Fixes\n- Fix a thing', path);
+
+    const changelog = readFileSync(path, 'utf-8');
+    expect(changelog).toContain('# Changelog');
+    expect(changelog).toContain(`## [3.4.1] - ${getToday()}`);
+    expect(changelog).toContain('- Fix a thing');
+  });
+
+  it('creates only the header via createInitialChangelog', () => {
+    const content = createInitialChangelog(path);
+    expect(readFileSync(path, 'utf-8')).toBe(content);
+    expect(content).toContain('Semantic Versioning');
+  });
+
+  it('inserts a new entry directly after the header', () => {
+    writeFileSync(path, HEADER);
+
+    insertChangelogEntry('3.4.1', '### New Features\n- Add a thing', path);
+
+    const changelog = readFileSync(path, 'utf-8');
+    const headerEnd = changelog.indexOf('---\n') + 4;
+    expect(changelog.indexOf('## [3.4.1]')).toBeGreaterThan(headerEnd);
+  });
+
+  it('preserves prior entries and puts the newest one first', () => {
+    writeFileSync(path, `${HEADER}## [3.4.0] - 2026-08-01\n\n### New Features\n- Older entry\n\n`);
+
+    insertChangelogEntry('3.4.1', '### Bug Fixes\n- Newer entry', path);
+
+    const changelog = readFileSync(path, 'utf-8');
+    expect(changelog).toContain('- Older entry');
+    expect(changelog).toContain('- Newer entry');
+    expect(changelog.indexOf('## [3.4.1]')).toBeLessThan(changelog.indexOf('## [3.4.0]'));
+  });
+
+  it('replaces heading and body when the version already exists', () => {
+    writeFileSync(path, `${HEADER}## [3.4.1] - 2026-08-01\n\n### Bug Fixes\n- Stale text\n\n`);
+
+    insertChangelogEntry('3.4.1', '### Bug Fixes\n- Fresh text', path);
+
+    const changelog = readFileSync(path, 'utf-8');
+    expect(changelog).toContain(`## [3.4.1] - ${getToday()}`);
+    expect(changelog.match(/- Fresh text/g)).toHaveLength(1);
+    expect(changelog).not.toContain('- Stale text');
+    expect(changelog.match(/## \[3\.4\.1\]/g)).toHaveLength(1);
+  });
+
+  it('replaces a duplicate entry without disturbing the entries around it', () => {
+    writeFileSync(
+      path,
+      `${HEADER}## [3.4.2] - 2026-08-02\n\n### Changes\n- Newest entry\n\n` +
+        `## [3.4.1] - 2026-08-01\n\n### Bug Fixes\n- Stale text\n\n` +
+        `## [3.4.0] - 2026-07-30\n\n### Changes\n- Oldest entry\n`
+    );
+
+    insertChangelogEntry('3.4.1', '### Bug Fixes\n- Fresh text', path);
+
+    const changelog = readFileSync(path, 'utf-8');
+    expect(changelog.match(/- Fresh text/g)).toHaveLength(1);
+    expect(changelog).not.toContain('- Stale text');
+    expect(changelog).toContain('- Newest entry');
+    expect(changelog).toContain('- Oldest entry');
+    expect(changelog.match(/^## \[/gm)).toHaveLength(3);
+    expect(changelog.indexOf('## [3.4.2]')).toBeLessThan(changelog.indexOf('## [3.4.1]'));
+    expect(changelog.indexOf('## [3.4.1]')).toBeLessThan(changelog.indexOf('## [3.4.0]'));
+  });
+
+  it('replaces the last entry cleanly when nothing follows it', () => {
+    writeFileSync(
+      path,
+      `${HEADER}## [3.4.2] - 2026-08-02\n\n### Changes\n- Keep me\n\n` +
+        `## [3.4.1] - 2026-08-01\n\n### Bug Fixes\n- Stale text\n`
+    );
+
+    insertChangelogEntry('3.4.1', '### Bug Fixes\n- Fresh text', path);
+
+    const changelog = readFileSync(path, 'utf-8');
+    expect(changelog.match(/- Fresh text/g)).toHaveLength(1);
+    expect(changelog).not.toContain('- Stale text');
+    expect(changelog).toContain('- Keep me');
+    expect(changelog.match(/^## \[/gm)).toHaveLength(2);
+  });
+
+  it('does not treat regex replacement patterns in content as substitutions', () => {
+    writeFileSync(path, `${HEADER}## [3.4.1] - 2026-08-01\n\n### Bug Fixes\n- Stale text\n\n`);
+
+    insertChangelogEntry('3.4.1', "### Bug Fixes\n- Fix $& and $' parsing", path);
+
+    expect(readFileSync(path, 'utf-8')).toContain("- Fix $& and $' parsing");
+  });
+
+  it('appends to a file that has no recognisable header', () => {
+    writeFileSync(path, 'Some unrelated notes\n');
+
+    insertChangelogEntry('3.4.1', '### Bug Fixes\n- Fix a thing', path);
+
+    const changelog = readFileSync(path, 'utf-8');
+    expect(changelog).toContain('Some unrelated notes');
+    expect(changelog).toContain('## [3.4.1]');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    include: ['packages/*/src/**/*.test.{ts,tsx}'],
+    include: ['packages/*/src/**/*.test.{ts,tsx}', 'scripts/**/*.test.js'],
     coverage: {
       provider: 'v8',
       include: ['packages/*/src/**/*.{ts,tsx}'],


### PR DESCRIPTION
PR6 of the prod-grade plan - the 515-line release machinery in `scripts/` was eslint-ignored, untested, and the AI changelog had silently fallen back to raw git subjects since 3.2.0.

**Root cause of the fallback (3 layers, all fixed):**
1. The repo had NO `ANTHROPIC_API_KEY` secret -> SDK auth error on every train run. Secret now set (done outside this PR).
2. `train.yml` ran the script with `2>/dev/null` -> the reason was invisible. Now stderr reaches the job log (fallback behavior unchanged).
3. Model was deprecated `claude-sonnet-4-20250514` (retires 2026-06-15) -> now `claude-sonnet-5` (no sampling params - sonnet-5 rejects them), plus a loud upfront missing-key guard (stderr + exit 1).

**Hardening:**
- `scripts/` now linted (verify pipeline includes it) - all violations fixed.
- Scripts refactored to export pure functions with entry guards; **34 new in-process unit tests** (suite 212 -> 246): bump patch/minor/major paths, changelog insertion/replacement, prompt construction, fallback formatting.
- **Real bug found & fixed by the new tests**: `update-changelog.js`'s duplicate-version path replaced only the heading, orphaning the stale body below the fresh one; regex also mis-anchored `$` under the `m` flag and would truncate entries containing `---`. Now replaces the full entry, `$`-substitution-safe.

**Verified**
- `npm run verify` exit 0 end-to-end (246 tests, lint incl. scripts, verify:pack).
- Missing-key path proven: `ANTHROPIC_API_KEY= node scripts/generate-changelog.js` -> clear stderr error, exit 1, stdout empty (train fallback intact).
- **Live end-to-end proof**: ran the script with the real key against the v3.4.0..HEAD range - produced a real categorized changelog entry via claude-sonnet-5, exit 0.
