### PR TITLE
chore: package metadata, lockstep internal deps, security/contributing docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Repository:** `chemistry/chemical-libraries`
 **Default Branch:** `master`
-**Monorepo:** npm workspaces with TypeScript composite projects
+**Monorepo:** npm workspaces with an explicitly ordered build script (no TypeScript project references)
 
 ## Development Commands
 
@@ -19,7 +19,8 @@ npm test                 # Run Vitest unit tests
 npm run type-check       # TypeScript checking
 npm run lint             # ESLint
 npm run format:check     # Prettier check
-npm run verify           # Full pipeline: type-check + lint + build + test
+npm run verify:pack      # publint + attw + packed-file check + consumer fixture
+npm run verify           # Full pipeline: type-check + lint + format:check + test + build + verify:pack
 npm run clean            # Clean build artifacts
 ```
 
@@ -55,7 +56,7 @@ packages/
 
 ## Publishing
 
-All packages are published to npm under the `@chemistry` scope. **Never run `npm publish` manually** — tag `v*` and push to trigger the release pipeline.
+All packages are published to npm under the `@chemistry` scope. Releases are **not** tag-triggered: they ship via `.github/workflows/train.yml` (Friday cron, or `workflow_dispatch` with a `bump` input of `auto`/`patch`/`minor`/`major`/`none`), which bumps versions, publishes with OIDC trusted publishing, and tags the result. **Never run `npm publish` manually.**
 
 ## Standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+## Setup
+
+Node.js >= 22 (see `.nvmrc`), npm >= 10.
+
+```bash
+npm ci
+npm run verify
+```
+
+`npm run verify` runs, in order: `type-check` (tsc --noEmit), `lint` (ESLint), `format:check` (Prettier), `test` (Vitest + coverage), `build` (dependency-ordered tsc), and `verify:pack`. The last one runs publint and are-the-types-wrong against every publishable package, checks the packed file list for leaks, then type-checks and runs the consumer fixture in `tools/consumer-check/`.
+
+## Tests
+
+- Package tests: `*.test.ts` colocated with source in `packages/<pkg>/src/`.
+- Script tests: `scripts/*.test.js`.
+- Coverage threshold is 70% (branches, functions, lines, statements).
+
+## Commits
+
+Conventional commits, subject <= 72 characters: `feat:`, `fix:`, `chore:`, `docs:`.
+
+## Pull Requests
+
+Open PRs against `master`. `npm run verify` must pass before review.
+
+## Releases
+
+Releases ship through the Friday release train (`.github/workflows/train.yml`), which bumps versions, publishes with OIDC trusted publishing, and tags the result. **Never run `npm publish` manually.**

--- a/README.md
+++ b/README.md
@@ -53,25 +53,28 @@ const sg = SpaceGroup.getById(225);
 ## Tech Stack
 
 - **Monorepo:** npm workspaces
-- **Language:** TypeScript 5.9, strict mode, ESM-only
+- **Language:** TypeScript 6, strict mode, ESM-only
 - **Testing:** Vitest, 70% coverage threshold
 - **Linting:** ESLint flat config + typescript-eslint + Prettier
 - **CI/CD:** GitHub Actions — automated weekly releases
-- **Target:** ES2024, isomorphic (Node.js 20+ & modern browsers)
+- **Target:** ES2024, isomorphic (Node.js 22+ & modern browsers)
 
 ## Development
 
 ```bash
 npm install
 npm run build
-npm run verify    # type-check + lint + format:check + test + build
+npm run verify    # type-check + lint + format:check + test + build + verify:pack
 ```
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full workflow and [SECURITY.md](./SECURITY.md) to report a vulnerability.
 
 ## Commands
 
 | Command                | Description                             |
 | ---------------------- | --------------------------------------- |
 | `npm run verify`       | Full validation pipeline                |
+| `npm run verify:pack`  | Packaging + consumer checks             |
 | `npm run build`        | Build all packages (dependency-ordered) |
 | `npm run test`         | Run unit tests                          |
 | `npm run lint`         | Lint source code                        |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 3.x     | Yes       |
+| < 3.0   | No        |
+
+Only the latest `3.x` release receives security fixes.
+
+## Reporting a Vulnerability
+
+Report privately through [GitHub Security Advisories](https://github.com/chemistry/chemical-libraries/security/advisories/new) on this repository. Please do not open a public issue for a security report.
+
+Expect an acknowledgment within a few days.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3391,7 +3391,7 @@
       "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
-        "@chemistry/elements": "^3.0.0"
+        "@chemistry/elements": "^3.4.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -3402,7 +3402,7 @@
       "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
-        "@chemistry/common": "^3.0.0"
+        "@chemistry/common": "^3.4.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -3413,9 +3413,9 @@
       "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
-        "@chemistry/common": "^3.0.0",
-        "@chemistry/elements": "^3.0.0",
-        "@chemistry/math": "^3.0.0",
+        "@chemistry/common": "^3.4.0",
+        "@chemistry/elements": "^3.4.0",
+        "@chemistry/math": "^3.4.0",
         "redux": "^5.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/chemistry/chemical-libraries.git"
+    "url": "git+https://github.com/chemistry/chemical-libraries.git"
   },
+  "homepage": "https://github.com/chemistry/chemical-libraries#readme",
+  "bugs": "https://github.com/chemistry/chemical-libraries/issues",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,12 +20,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/chemistry/chemical-libraries.git",
+    "url": "git+https://github.com/chemistry/chemical-libraries.git",
     "directory": "packages/common"
   },
+  "homepage": "https://github.com/chemistry/chemical-libraries/tree/master/packages/common#readme",
+  "bugs": "https://github.com/chemistry/chemical-libraries/issues",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "private": false,
   "sideEffects": false,
@@ -34,7 +37,6 @@
     "dist",
     "src",
     "!src/**/*.test.ts",
-    "!src/**/*.test.tsx",
     "!src/**/__snapshots__",
     "README.md",
     "LICENSE"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -19,12 +19,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/chemistry/chemical-libraries.git",
+    "url": "git+https://github.com/chemistry/chemical-libraries.git",
     "directory": "packages/elements"
   },
+  "homepage": "https://github.com/chemistry/chemical-libraries/tree/master/packages/elements#readme",
+  "bugs": "https://github.com/chemistry/chemical-libraries/issues",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "private": false,
   "sideEffects": false,
@@ -33,7 +36,6 @@
     "dist",
     "src",
     "!src/**/*.test.ts",
-    "!src/**/*.test.tsx",
     "!src/**/__snapshots__",
     "README.md",
     "LICENSE"

--- a/packages/formula/package.json
+++ b/packages/formula/package.json
@@ -18,12 +18,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/chemistry/chemical-libraries.git",
+    "url": "git+https://github.com/chemistry/chemical-libraries.git",
     "directory": "packages/formula"
   },
+  "homepage": "https://github.com/chemistry/chemical-libraries/tree/master/packages/formula#readme",
+  "bugs": "https://github.com/chemistry/chemical-libraries/issues",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "private": false,
   "sideEffects": false,
@@ -32,7 +35,6 @@
     "dist",
     "src",
     "!src/**/*.test.ts",
-    "!src/**/*.test.tsx",
     "!src/**/__snapshots__",
     "README.md",
     "LICENSE"
@@ -51,6 +53,6 @@
     "prepack": "rm -rf dist && tsc"
   },
   "dependencies": {
-    "@chemistry/elements": "^3.0.0"
+    "@chemistry/elements": "^3.4.0"
   }
 }

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -18,12 +18,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/chemistry/chemical-libraries.git",
+    "url": "git+https://github.com/chemistry/chemical-libraries.git",
     "directory": "packages/math"
   },
+  "homepage": "https://github.com/chemistry/chemical-libraries/tree/master/packages/math#readme",
+  "bugs": "https://github.com/chemistry/chemical-libraries/issues",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "private": false,
   "sideEffects": false,
@@ -32,7 +35,6 @@
     "dist",
     "src",
     "!src/**/*.test.ts",
-    "!src/**/*.test.tsx",
     "!src/**/__snapshots__",
     "README.md",
     "LICENSE"
@@ -51,6 +53,6 @@
     "prepack": "rm -rf dist && tsc"
   },
   "dependencies": {
-    "@chemistry/common": "^3.0.0"
+    "@chemistry/common": "^3.4.0"
   }
 }

--- a/packages/molecule/package.json
+++ b/packages/molecule/package.json
@@ -15,17 +15,20 @@
     "atoms",
     "bonds"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/chemistry/chemical-libraries.git",
-    "directory": "packages/molecule"
-  },
   "engines": {
     "node": ">=22.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chemistry/chemical-libraries.git",
+    "directory": "packages/molecule"
+  },
+  "homepage": "https://github.com/chemistry/chemical-libraries/tree/master/packages/molecule#readme",
+  "bugs": "https://github.com/chemistry/chemical-libraries/issues",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "private": false,
   "sideEffects": false,
@@ -34,7 +37,6 @@
     "dist",
     "src",
     "!src/**/*.test.ts",
-    "!src/**/*.test.tsx",
     "!src/**/__snapshots__",
     "README.md",
     "LICENSE"
@@ -53,9 +55,9 @@
     "prepack": "rm -rf dist && tsc"
   },
   "dependencies": {
-    "@chemistry/common": "^3.0.0",
-    "@chemistry/elements": "^3.0.0",
-    "@chemistry/math": "^3.0.0",
+    "@chemistry/common": "^3.4.0",
+    "@chemistry/elements": "^3.4.0",
+    "@chemistry/math": "^3.4.0",
     "redux": "^5.0.0"
   }
 }

--- a/packages/molecule/src/index.ts
+++ b/packages/molecule/src/index.ts
@@ -1,3 +1,5 @@
 export * from './molecule.js';
 export * from './models.js';
 export * from './store/svg-export.js';
+// Surfaces the state shape that exportToSVG and Molecule.export already expose publicly
+export type { IMoleculeState } from './store/reducer.js';

--- a/packages/space-groups/package.json
+++ b/packages/space-groups/package.json
@@ -19,14 +19,17 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/chemistry/chemical-libraries.git",
+    "url": "git+https://github.com/chemistry/chemical-libraries.git",
     "directory": "packages/space-groups"
+  },
+  "homepage": "https://github.com/chemistry/chemical-libraries/tree/master/packages/space-groups#readme",
+  "bugs": "https://github.com/chemistry/chemical-libraries/issues",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
   },
   "private": false,
   "sideEffects": false,
@@ -35,7 +38,6 @@
     "dist",
     "src",
     "!src/**/*.test.ts",
-    "!src/**/*.test.tsx",
     "!src/**/__snapshots__",
     "README.md",
     "LICENSE"

--- a/scripts/bump-versions.js
+++ b/scripts/bump-versions.js
@@ -128,6 +128,45 @@ export function updatePackageVersion(pkgPath, newVersion) {
   return { oldVersion, newVersion };
 }
 
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
+
+/**
+ * Pin internal workspace dependency ranges to the freshly bumped version.
+ * External ranges are left untouched.
+ */
+export function updateInternalDependencies(pkgPath, newVersion, internalNames) {
+  const internal = new Set(internalNames);
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  const range = `^${newVersion}`;
+  const changed = [];
+
+  for (const field of DEPENDENCY_FIELDS) {
+    const deps = pkg[field];
+    if (!deps) {
+      continue;
+    }
+
+    for (const name of Object.keys(deps)) {
+      if (!internal.has(name) || deps[name] === range) {
+        continue;
+      }
+      changed.push({ field, name, oldRange: deps[name], newRange: range });
+      deps[name] = range;
+    }
+  }
+
+  if (changed.length > 0) {
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  }
+
+  return changed;
+}
+
 export function main() {
   const bumpType = process.argv[2] || 'patch';
 
@@ -176,6 +215,25 @@ export function main() {
 
   console.log('');
   console.log(`Updated ${updated.length} packages to version ${newVersion}`);
+
+  // Ranges are pinned after the bump so a release never ships against a stale sibling
+  const internalNames = packages.filter((pkg) => !pkg.isRoot).map((pkg) => pkg.name);
+  const relinked = packages.flatMap((pkg) =>
+    updateInternalDependencies(pkg.path, newVersion, internalNames).map((change) => ({
+      ...change,
+      pkgName: pkg.name,
+    }))
+  );
+
+  if (relinked.length > 0) {
+    console.log('');
+    console.log('Relinking internal dependencies:');
+    for (const change of relinked) {
+      console.log(`  ${change.pkgName}: ${change.name} ${change.oldRange} -> ${change.newRange}`);
+    }
+    console.log('');
+    console.log(`Relinked ${relinked.length} internal dependency ranges to ^${newVersion}`);
+  }
 
   console.log('');
   console.log(`NEW_VERSION=${newVersion}`);

--- a/scripts/bump-versions.test.js
+++ b/scripts/bump-versions.test.js
@@ -9,6 +9,7 @@ import {
   expandGlobPattern,
   getWorkspacePackages,
   updatePackageVersion,
+  updateInternalDependencies,
 } from './bump-versions.js';
 
 function writeManifest(dir, manifest) {
@@ -131,5 +132,107 @@ describe('workspace discovery against a fixture monorepo', () => {
     expect(read('alpha')).toBe('3.5.0');
     expect(read('beta')).toBe('3.5.0');
     expect(read('legacy')).toBe('2.1.0');
+  });
+});
+
+describe('internal dependency lockstep', () => {
+  let root;
+  const internalNames = ['@fixture/alpha', '@fixture/beta'];
+
+  const readManifest = (name) =>
+    JSON.parse(readFileSync(join(root, 'packages', name, 'package.json'), 'utf-8'));
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'bump-deps-'));
+    writeManifest(root, {
+      name: 'root',
+      version: '3.4.0',
+      private: true,
+      workspaces: ['packages/*'],
+    });
+    writeManifest(join(root, 'packages', 'alpha'), { name: '@fixture/alpha', version: '3.4.0' });
+    writeManifest(join(root, 'packages', 'beta'), {
+      name: '@fixture/beta',
+      version: '3.4.0',
+      dependencies: { '@fixture/alpha': '^3.0.0', redux: '^5.0.0' },
+      devDependencies: { vitest: '^4.0.0' },
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('rewrites internal dependency ranges to the bumped version', () => {
+    const pkgPath = join(root, 'packages', 'beta', 'package.json');
+    const changes = updateInternalDependencies(pkgPath, '3.5.0', internalNames);
+
+    expect(readManifest('beta').dependencies['@fixture/alpha']).toBe('^3.5.0');
+    expect(changes).toEqual([
+      {
+        field: 'dependencies',
+        name: '@fixture/alpha',
+        oldRange: '^3.0.0',
+        newRange: '^3.5.0',
+      },
+    ]);
+  });
+
+  it('leaves external dependency ranges untouched', () => {
+    updateInternalDependencies(join(root, 'packages', 'beta', 'package.json'), '3.5.0', [
+      ...internalNames,
+    ]);
+
+    const beta = readManifest('beta');
+    expect(beta.dependencies.redux).toBe('^5.0.0');
+    expect(beta.devDependencies.vitest).toBe('^4.0.0');
+  });
+
+  it('rewrites internal ranges across every dependency field', () => {
+    const pkgPath = join(root, 'packages', 'beta', 'package.json');
+    const beta = readManifest('beta');
+    beta.peerDependencies = { '@fixture/alpha': '^3.0.0' };
+    beta.optionalDependencies = { '@fixture/alpha': '^3.0.0' };
+    writeFileSync(pkgPath, JSON.stringify(beta, null, 2) + '\n');
+
+    updateInternalDependencies(pkgPath, '3.5.0', internalNames);
+
+    const updated = readManifest('beta');
+    expect(updated.peerDependencies['@fixture/alpha']).toBe('^3.5.0');
+    expect(updated.optionalDependencies['@fixture/alpha']).toBe('^3.5.0');
+  });
+
+  it('is a no-op when a manifest has no internal dependencies', () => {
+    const changes = updateInternalDependencies(
+      join(root, 'packages', 'alpha', 'package.json'),
+      '3.5.0',
+      internalNames
+    );
+
+    expect(changes).toEqual([]);
+    expect(readManifest('alpha')).toEqual({ name: '@fixture/alpha', version: '3.4.0' });
+  });
+
+  it('reports no changes when ranges already match the new version', () => {
+    const pkgPath = join(root, 'packages', 'beta', 'package.json');
+    updateInternalDependencies(pkgPath, '3.5.0', internalNames);
+
+    expect(updateInternalDependencies(pkgPath, '3.5.0', internalNames)).toEqual([]);
+  });
+
+  it('keeps versions and internal ranges in lockstep across a full bump', () => {
+    const packages = getWorkspacePackages(root);
+    const newVersion = bumpVersion(packages[0].version, 'minor');
+    const names = packages.filter((pkg) => !pkg.isRoot).map((pkg) => pkg.name);
+
+    for (const pkg of packages) {
+      updatePackageVersion(pkg.path, newVersion);
+      updateInternalDependencies(pkg.path, newVersion, names);
+    }
+
+    const beta = readManifest('beta');
+    expect(beta.version).toBe('3.5.0');
+    expect(beta.dependencies['@fixture/alpha']).toBe('^3.5.0');
+    expect(beta.dependencies.redux).toBe('^5.0.0');
   });
 });

--- a/tools/consumer-check/consumer.ts
+++ b/tools/consumer-check/consumer.ts
@@ -7,6 +7,7 @@ import { Formula } from '@chemistry/formula';
 import type { ChemComposition } from '@chemistry/formula';
 import { Quaternion, Vec3 } from '@chemistry/math';
 import { defaultSvgOptions, exportToSVG, Molecule, MoleculeDataFormat } from '@chemistry/molecule';
+import type { IMoleculeState } from '@chemistry/molecule';
 import { CrystalSystem, SpaceGroup } from '@chemistry/space-groups';
 import type { SpaceGroupInfo } from '@chemistry/space-groups';
 
@@ -26,7 +27,8 @@ const data: JNMol = { id: 'm1', title: 'empty', atoms: {}, bonds: {} };
 const molecule = new Molecule();
 molecule.load(data, MoleculeDataFormat.jnmol);
 const atomCount: number = molecule.getAtomCount();
-const svg: string = exportToSVG(molecule.export(MoleculeDataFormat.jnmol), defaultSvgOptions);
+const state: IMoleculeState = molecule.export(MoleculeDataFormat.jnmol);
+const svg: string = exportToSVG(state, defaultSvgOptions);
 
 const group: SpaceGroupInfo | null = SpaceGroup.getById(1);
 const system: CrystalSystem | null = group ? SpaceGroup.getCrystalSystem(group) : null;


### PR DESCRIPTION
PR7 of the prod-grade plan - closes the remaining metadata/docs gaps.

- **Manifests (all 6 + root)**: `git+` repository URLs, `homepage`/`bugs`, explicit `publishConfig.provenance: true`, dead `.test.tsx` negation removed, key order normalized across all 6. `funding` deliberately skipped - no FUNDING.yml/sponsors target exists anywhere (verified via API).
- **Internal deps lockstep**: the 4 dependent packages now pin `@chemistry/*` at `^3.4.0` (was floating `^3.0.0`), and `bump-versions.js` rewrites internal ranges on every bump so they never drift again (+6 tests, incl. externals-untouched and idempotency).
- **`IMoleculeState` exported** from the molecule barrel (was in `exportToSVG`'s public signature but unimportable); consumer fixture asserts it - proven non-vacuous via a negative control (bogus import -> TS2305).
- **SECURITY.md + CONTRIBUTING.md** added (terse); README drift fixed (Node 22+, TS 6, verify:pack); CLAUDE.md corrected (no composite projects; releases ship via train.yml, not tags).

**Verified**: `npm run verify` exit 0 (252 tests); **publint now reports "All good!" on all 6 packages - zero suggestions**; lockfile regenerated with npm@10, `npm ci --dry-run` clean; bump script exercised end-to-end on a scratch copy (minor bump relinked all internal ranges to ^3.5.0, redux untouched).
