### PR TITLE
fix: check-pack handles npm 12 pack --json object shape

### DIFF
--- a/scripts/check-pack.js
+++ b/scripts/check-pack.js
@@ -13,7 +13,7 @@
 import { spawnSync } from 'child_process';
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
@@ -94,22 +94,69 @@ function fail(name, step, result, details = []) {
 }
 
 /**
- * Read the tarball file list; lifecycle script output may precede the JSON payload
+ * Extract the first parseable JSON value from pack output; npm may surround the
+ * payload with lifecycle notices, and npm >=12 emits an object instead of an array
  */
+export function extractJsonPayload(text) {
+  for (let start = 0; start < text.length; start++) {
+    if (text[start] !== '[' && text[start] !== '{') {
+      continue;
+    }
+    const candidate = balancedSlice(text, start);
+    if (candidate !== null && parses(candidate)) {
+      return JSON.parse(candidate);
+    }
+  }
+  return null;
+}
+
+function balancedSlice(text, start) {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (escaped) {
+      escaped = false;
+    } else if (ch === '\\') {
+      escaped = inString;
+    } else if (ch === '"') {
+      inString = !inString;
+    } else if (!inString && (ch === '[' || ch === '{')) {
+      depth++;
+    } else if (!inString && (ch === ']' || ch === '}') && --depth === 0) {
+      return text.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+function parses(candidate) {
+  try {
+    JSON.parse(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function packFileList(name) {
-  const result = run('npm', ['pack', '--dry-run', '--json', '-w', name], rootDir);
+  const result = run(
+    'npm',
+    ['pack', '--dry-run', '--json', '--silent', '--foreground-scripts=false', '-w', name],
+    rootDir
+  );
   if (result.status !== 0) {
     return { result, files: null };
   }
 
-  const start = result.stdout.indexOf('[');
-  const end = result.stdout.lastIndexOf(']');
-  if (start === -1 || end === -1) {
+  const parsed = extractJsonPayload(result.stdout);
+  // npm <=11 emits [{...}]; npm >=12 emits {"<pkg name>": {...}}
+  const entry = Array.isArray(parsed) ? parsed[0] : parsed && Object.values(parsed)[0];
+  if (!entry || !Array.isArray(entry.files)) {
     return { result, files: null };
   }
-
-  const parsed = JSON.parse(result.stdout.slice(start, end + 1));
-  return { result, files: parsed[0].files.map((entry) => entry.path) };
+  return { result, files: entry.files.map((item) => item.path) };
 }
 
 function inspectFileList(files) {
@@ -175,4 +222,9 @@ function main() {
   console.log('\nPackage validation passed.');
 }
 
-main();
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  main();
+}

--- a/scripts/check-pack.test.js
+++ b/scripts/check-pack.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { extractJsonPayload } from './check-pack.js';
+
+const FILES = [{ path: 'package.json' }, { path: 'dist/index.js' }, { path: 'LICENSE' }];
+const ARRAY_SHAPE = JSON.stringify([{ name: '@chemistry/common', files: FILES }]);
+const OBJECT_SHAPE = JSON.stringify({ '@chemistry/common': { files: FILES, bundled: [] } });
+
+describe('extractJsonPayload', () => {
+  it('parses the npm <=11 array shape', () => {
+    expect(extractJsonPayload(ARRAY_SHAPE)).toEqual(JSON.parse(ARRAY_SHAPE));
+  });
+
+  it('parses the npm >=12 object shape', () => {
+    expect(extractJsonPayload(OBJECT_SHAPE)).toEqual(JSON.parse(OBJECT_SHAPE));
+  });
+
+  it('skips lifecycle noise before the payload', () => {
+    const polluted = `npm notice run @chemistry/common@3.5.0 prepack\nnpm notice run tsc\n${OBJECT_SHAPE}`;
+    expect(extractJsonPayload(polluted)).toEqual(JSON.parse(OBJECT_SHAPE));
+  });
+
+  it('ignores trailing noise, even when it contains brackets', () => {
+    const polluted = `${ARRAY_SHAPE}\nnpm notice run rm -rf packages/*/dist\n[extra] trailing ] junk }`;
+    expect(extractJsonPayload(polluted)).toEqual(JSON.parse(ARRAY_SHAPE));
+  });
+
+  it('skips non-JSON bracketed noise before the payload', () => {
+    const polluted = `notice [pre] {junk} lines\n${OBJECT_SHAPE}\nnotice [post]`;
+    expect(extractJsonPayload(polluted)).toEqual(JSON.parse(OBJECT_SHAPE));
+  });
+
+  it('is not confused by brackets inside JSON strings', () => {
+    const tricky = JSON.stringify([{ files: [{ path: 'weird}].name[{.js' }] }]);
+    expect(extractJsonPayload(`noise\n${tricky}\nnoise ]}`)).toEqual(JSON.parse(tricky));
+  });
+
+  it('returns null when no JSON value is present', () => {
+    expect(extractJsonPayload('npm notice nothing here')).toBeNull();
+    expect(extractJsonPayload('[unterminated')).toBeNull();
+    expect(extractJsonPayload('{"also": "unterminated"')).toBeNull();
+  });
+});


### PR DESCRIPTION
Hotfix for the failed train run (31545537493): the train installs `npm@latest` for OIDC, which is now **npm 12.0.2**, and npm 12 changed `npm pack --dry-run --json -w` output from an array `[{...}]` to an object keyed by package name. `check-pack.js`'s first-`[`-to-last-`]` slice then captured a mid-object fragment -> `JSON.parse` failure -> Verify died before the version commit/tag/publish (master and npm untouched, by design of the #65 fail-loud fix).

- `extractJsonPayload()` now scans for the first *parseable* JSON value (array or object, string-aware balanced-bracket matching, skips non-JSON bracketed noise on either side) and `packFileList` normalizes both shapes.
- Pack invocation adds `--silent --foreground-scripts=false` to cut lifecycle noise at the source.
- Entry guard added so the script is importable; 7 unit tests covering both shapes + pollution cases (suite 252 -> 259).

**Verified**
- Reproduced the exact CI environment: installed npm 12.0.2 in an isolated prefix, confirmed the old code's failure mode, and ran the fixed `check-pack.js` under it - all 6 packages validate ("Package validation passed").
- Full `npm run verify` also green under npm 11.7 (local) - both output shapes handled.
