### PR TITLE
fix: changelog generation - low effort, empty-text guard, 16k budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.5.0] - 2026-08-11
 
-### Changes
+### Bug Fixes
 
-- fix: check-pack handles npm 12 pack --json object shape (#80)
-- chore: package metadata, lockstep internal deps, security/contributing docs (#79)
-- chore(deps-dev): bump the all-dependencies group across 1 directory with 2 updates (#72)
-- chore: lint+test release scripts, fix AI changelog silent fallback (#78)
-- ci: fail-closed prod audit, Node 22/24 matrix (#77)
-- ci: packaging validation - publint, attw, pack checks, consumer fixture (#76)
-- ci: enforce coverage thresholds, raise formula branch coverage (#75)
+- Fix packaging validation for npm 12 pack output
+
+No other user-facing changes in this release.
 
 ## [3.4.0] - 2026-08-11
 

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -18,7 +18,7 @@ import { execSync } from 'child_process';
 import { pathToFileURL } from 'url';
 
 const MODEL = 'claude-sonnet-5';
-const MAX_TOKENS = 8192;
+const MAX_TOKENS = 16000;
 
 export const CHANGELOG_PROMPT = `You are a changelog generator for @chemistry/* — a set of open-source cheminformatics libraries for JavaScript.
 The monorepo contains packages: @chemistry/common, @chemistry/elements, @chemistry/formula, @chemistry/math, @chemistry/molecule, @chemistry/space-groups.
@@ -118,6 +118,8 @@ export async function generateChangelog(commits, client = new Anthropic()) {
   const message = await client.messages.create({
     model: MODEL,
     max_tokens: MAX_TOKENS,
+    // Low effort keeps adaptive thinking from consuming the text budget on this simple task
+    output_config: { effort: 'low' },
     messages: [
       {
         role: 'user',
@@ -126,7 +128,11 @@ export async function generateChangelog(commits, client = new Anthropic()) {
     ],
   });
 
-  return extractTextContent(message);
+  const text = extractTextContent(message);
+  if (!text) {
+    throw new Error(`API returned no text (stop_reason: ${message.stop_reason})`);
+  }
+  return text;
 }
 
 export async function main() {


### PR DESCRIPTION
Second changelog fix - the 3.5.0 train fell back to raw git subjects even with the key set, and thanks to #78's un-swallowed stderr the cause was visible: the API call SUCCEEDED but returned empty text.

**Root cause:** on `claude-sonnet-5`, adaptive thinking is on by default and shares the `max_tokens` budget. With 8192, the model can spend (nearly) the whole budget thinking and return no text blocks - nondeterministic, which is why the pre-merge live test passed.

- `output_config: { effort: 'low' }` - a changelog needs no deep thinking; this stops the budget consumption at the source.
- `max_tokens` 8192 -> 16000 for headroom.
- Empty-text guard: `generateChangelog` now throws with the `stop_reason` when the API returns no text, so the train's fallback engages with a visible reason instead of silently.
- **CHANGELOG repaired**: the raw-subjects 3.5.0 entry replaced with a properly generated one (exercising #78's fixed duplicate-entry replacement path).

**Verified:** fixed path run 3x live against the real v3.4.0..v3.5.0 range - consistent categorized output every time (previously flaky); full `npm run verify` green (259 tests).
