### PR TITLE
chore(train): move to the Saturday 03:00-09:00 UTC window

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -4,7 +4,7 @@ name: Train
 # Red run = the only alarm; there are no silent-skip states.
 on:
   schedule:
-    - cron: '7 19 * * 5'
+    - cron: '41 4 * * 6'
   workflow_dispatch:
     inputs:
       bump:


### PR DESCRIPTION
Estate-wide retime (post 2026-08-28 cron outage + timing research): Friday evening UTC is GitHub's documented daily load peak; the train moves to Sat 03:00-09:00 UTC. This repo's new slot: `41 4 * * 6`. Dependabot stays Friday 16:xx (own scheduler). Conductor + host cron retimed in the same sweep.